### PR TITLE
Added return field to cheatsheet items in 0-camera, 0-dimension, 0-exif, 0-field-methods, 0-file, 0-files & 0-helpers

### DIFF
--- a/content/1-docs/9-cheatsheet/0-camera/0-make/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-camera/0-make/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Returns the camera brand/make
 
 ----
 
+Return:
+
+type: string
+text:
+
+----
+
 Text:
 
 ## Example
@@ -17,4 +24,3 @@ Text:
 ```php
 <?php echo $page->image()->exif()->camera()->make() ?>
 ```
-

--- a/content/1-docs/9-cheatsheet/0-camera/0-model/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-camera/0-model/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Returns the name of the camera model
 
 ----
 
+Return:
+
+type: string
+text:
+
+----
+
 Text:
 
 ## Example
@@ -17,4 +24,3 @@ Text:
 ```php
 <?php echo $page->image()->exif()->camera()->model() ?>
 ```
-

--- a/content/1-docs/9-cheatsheet/0-camera/0-to-array/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-camera/0-to-array/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Returns the make and model as associative array.
 
 ----
 
+Return:
+
+type: array
+text:
+
+----
+
 Text:
 
 ## Example
@@ -17,4 +24,3 @@ Text:
 ```php
 <?php echo $page->image()->exif()->camera()->toArray() ?>
 ```
-

--- a/content/1-docs/9-cheatsheet/0-dimension/0-fit-height/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-dimension/0-fit-height/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Fits the height by the given value and returns a modified dimension object
 
 ----
 
+Return:
+
+type: $image
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-dimension/0-fit-width-and-height/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-dimension/0-fit-width-and-height/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Fits the width and height by the given values and returns a modified dimension o
 
 ----
 
+Return:
+
+type: $image;
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-dimension/0-fit-width/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-dimension/0-fit-width/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Fits the width by the given value and returns a modified dimension object
 
 ----
 
+Return:
+
+type: $image
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-dimension/0-fit/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-dimension/0-fit/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Fits the width and height into a box by the given value and returns a modified d
 
 ----
 
+Return:
+
+type: $image
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-dimension/0-height/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-dimension/0-height/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Returns the height in pixels
 
 ----
 
+Return:
+
+type: integer
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-dimension/0-landscape/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-dimension/0-landscape/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Checks if the dimensions are "landscape"
 
 ----
 
+Return:
+
+type: boolean
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-dimension/0-orientation/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-dimension/0-orientation/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Returns the orientation of the image as string (landscape|portrait|square)
 
 ----
 
+Return:
+
+type: string
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-dimension/0-portrait/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-dimension/0-portrait/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Checks if the dimensions are "portrait"
 
 ----
 
+Return:
+
+type: boolean
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-dimension/0-ratio/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-dimension/0-ratio/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Returns the ratio
 
 ----
 
+Return:
+
+type: float
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-dimension/0-square/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-dimension/0-square/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Checks if the dimensions are square
 
 ----
 
+Return:
+
+type: boolean
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-dimension/0-width/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-dimension/0-width/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Returns the width in pixels
 
 ----
 
+Return:
+
+type: integer
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-exif/0-aperture/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-exif/0-aperture/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Returns the aperture value of the image, if it is available in the exif data set
 
 ----
 
+Return:
+
+type: string
+text:
+
+----
+
 Text:
 
 ## Example
@@ -17,4 +24,3 @@ Text:
 ```php
 <?php echo $page->image()->exif()->aperture() ?>
 ```
-

--- a/content/1-docs/9-cheatsheet/0-exif/0-camera/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-exif/0-camera/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Returns the $camera object for the image, which contains the make and model.
 
 ----
 
+Return:
+
+type: $camera
+text:
+
+----
+
 Text:
 
 ```php
@@ -19,4 +26,3 @@ echo $camera->make();
 echo $camera->model();
 
 ```
-

--- a/content/1-docs/9-cheatsheet/0-exif/0-data/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-exif/0-data/cheatsheet.item.txt
@@ -10,9 +10,15 @@ Returns the full exif data set as a raw array.
 
 ----
 
+Return:
+
+type: array
+text:
+
+----
+
 Text:
 
 ```php
 dump($page->image()->exif()->data());
 ```
-

--- a/content/1-docs/9-cheatsheet/0-exif/0-exposure/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-exif/0-exposure/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Returns the exposure value of the image, if it is available in the exif data set
 
 ----
 
+Return:
+
+type: string
+text:
+
+----
+
 Text:
 
 ## Example
@@ -17,4 +24,3 @@ Text:
 ```php
 <?php echo $page->image()->exif()->exposure() ?>
 ```
-

--- a/content/1-docs/9-cheatsheet/0-exif/0-focal-length/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-exif/0-focal-length/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Returns the focal length of the image, if it is available in the exif data set.
 
 ----
 
+Return:
+
+type: string
+text:
+
+----
+
 Text:
 
 ## Example
@@ -17,4 +24,3 @@ Text:
 ```php
 <?php echo $page->image()->exif()->focalLength() ?>
 ```
-

--- a/content/1-docs/9-cheatsheet/0-exif/0-is-bw/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-exif/0-is-bw/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Checks if the image colorspace is grayscale
 
 ----
 
+Return:
+
+type: boolean
+text:
+
+----
+
 Text:
 
 ## Example
@@ -19,4 +26,3 @@ Text:
 This is a black and white picture
 <?php endif ?>
 ```
-

--- a/content/1-docs/9-cheatsheet/0-exif/0-is-color/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-exif/0-is-color/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Checks if the image colorspace is either RGB or CMYK
 
 ----
 
+Return:
+
+type: boolean
+text:
+
+----
+
 Text:
 
 ## Example
@@ -19,4 +26,3 @@ Text:
 This is a color picture
 <?php endif ?>
 ```
-

--- a/content/1-docs/9-cheatsheet/0-exif/0-iso/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-exif/0-iso/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Returns the iso value of the image, if it is available in the exif data set.
 
 ----
 
+Return:
+
+type: integer
+text:
+
+----
+
 Text:
 
 ## Example
@@ -17,4 +24,3 @@ Text:
 ```php
 <?php echo $page->image()->exif()->iso() ?>
 ```
-

--- a/content/1-docs/9-cheatsheet/0-exif/0-location/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-exif/0-location/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Returns the $location object for the image if the image has GPS data.
 
 ----
 
+Return:
+
+type: $location
+text:
+
+----
+
 Text:
 
 ```php
@@ -19,4 +26,3 @@ echo $location->lat();
 echo $location->lng();
 
 ```
-

--- a/content/1-docs/9-cheatsheet/0-exif/0-timestamp/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-exif/0-timestamp/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Returns the unix timestamp of when the image was taken.
 
 ----
 
+Return:
+
+type: string
+text:
+
+----
+
 Text:
 
 ## Example
@@ -17,4 +24,3 @@ Text:
 ```php
 <?php echo $page->image()->exif()->timestamp() ?>
 ```
-

--- a/content/1-docs/9-cheatsheet/0-exif/0-to-array/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-exif/0-to-array/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Returns an associative array of all available exif data.
 
 ----
 
+Return:
+
+type: array
+text:
+
+----
+
 Text:
 
 ## Example
@@ -17,4 +24,3 @@ Text:
 ```php
 <?php dump($page->image()->exif()->toArray()) ?>
 ```
-

--- a/content/1-docs/9-cheatsheet/0-field-methods/0-bool/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-field-methods/0-bool/cheatsheet.item.txt
@@ -6,6 +6,13 @@ Excerpt: Converts the field value into a proper boolean
 
 ----
 
+Return:
+
+type: boolean
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-field-methods/0-empty/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-field-methods/0-empty/cheatsheet.item.txt
@@ -6,6 +6,13 @@ Excerpt: Checks if the field is empty
 
 ----
 
+Return:
+
+type: boolean
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-field-methods/0-escape/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-field-methods/0-escape/cheatsheet.item.txt
@@ -6,6 +6,13 @@ Excerpt: Escapes all critical characters from the field content to make sure all
 
 ----
 
+Return:
+
+type: string
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-field-methods/0-excerpt/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-field-methods/0-excerpt/cheatsheet.item.txt
@@ -6,6 +6,13 @@ Excerpt: Creates a short text excerpt
 
 ----
 
+Return:
+
+type: string
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-field-methods/0-html/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-field-methods/0-html/cheatsheet.item.txt
@@ -6,6 +6,13 @@ Excerpt: Converts the field content to valid HTML
 
 ----
 
+Return:
+
+type: string
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-field-methods/0-int/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-field-methods/0-int/cheatsheet.item.txt
@@ -6,6 +6,13 @@ Excerpt: Converts the field value into a proper integer
 
 ----
 
+Return:
+
+type: integer
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-field-methods/0-kirbytext/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-field-methods/0-kirbytext/cheatsheet.item.txt
@@ -6,6 +6,13 @@ Excerpt: Converts the field content from Markdown/Kirbytext to valid HTML
 
 ----
 
+Return:
+
+type: string
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-field-methods/0-kt/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-field-methods/0-kt/cheatsheet.item.txt
@@ -6,6 +6,13 @@ Excerpt: Converts the field content from Markdown/Kirbytext to valid HTML
 
 ----
 
+Return:
+
+type: string
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-field-methods/0-length/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-field-methods/0-length/cheatsheet.item.txt
@@ -6,6 +6,13 @@ Excerpt: Returns the length of the field content
 
 ----
 
+Return:
+
+type: integer
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-field-methods/0-lower/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-field-methods/0-lower/cheatsheet.item.txt
@@ -6,6 +6,13 @@ Excerpt: Converts the field content to lowercase
 
 ----
 
+Return:
+
+type: string
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-field-methods/0-markdown/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-field-methods/0-markdown/cheatsheet.item.txt
@@ -6,6 +6,13 @@ Excerpt: Converts markdown to valid HTML
 
 ----
 
+Return:
+
+type: string
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-field-methods/0-or/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-field-methods/0-or/cheatsheet.item.txt
@@ -6,6 +6,13 @@ Excerpt: Checks if the field is empty and returns an alternative value in this c
 
 ----
 
+Return:
+
+type: any
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-field-methods/0-pages/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-field-methods/0-pages/cheatsheet.item.txt
@@ -6,6 +6,13 @@ Excerpt: Converts a yaml list of page URIs to valid page objects
 
 ----
 
+Return:
+
+type: $pages
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-field-methods/0-short/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-field-methods/0-short/cheatsheet.item.txt
@@ -6,6 +6,13 @@ Excerpt: Shortens the field content by the given length
 
 ----
 
+Return:
+
+type: string
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-field-methods/0-split/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-field-methods/0-split/cheatsheet.item.txt
@@ -6,6 +6,13 @@ Excerpt: Splits the field content into an array
 
 ----
 
+Return:
+
+type: array
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-field-methods/0-upper/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-field-methods/0-upper/cheatsheet.item.txt
@@ -6,6 +6,13 @@ Excerpt: Converts the field content to uppercase
 
 ----
 
+Return:
+
+type: string
+text:
+
+----
+
 Text:
 
 ```php

--- a/content/1-docs/9-cheatsheet/0-field-methods/0-widont/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-field-methods/0-widont/cheatsheet.item.txt
@@ -6,6 +6,13 @@ Excerpt: Avoids typographical widows in strings by replacing the last space with
 
 ----
 
+Return:
+
+type: string
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-field-methods/0-words/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-field-methods/0-words/cheatsheet.item.txt
@@ -6,6 +6,13 @@ Excerpt: Returns the number of words in the text
 
 ----
 
+Return:
+
+type: integer
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-field-methods/0-xml/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-field-methods/0-xml/cheatsheet.item.txt
@@ -6,6 +6,13 @@ Excerpt: Converts the field content to valid XML
 
 ----
 
+Return:
+
+type: string
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-field-methods/0-yaml/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-field-methods/0-yaml/cheatsheet.item.txt
@@ -6,6 +6,13 @@ Excerpt: Converts YAML-structured field content to an array
 
 ----
 
+Return:
+
+type: array
+text:
+
+----
+
 Text:
 
 You can store structured data in fields with YAML. YAML is a simple structuring syntax, which is easy to understand and use.

--- a/content/1-docs/9-cheatsheet/0-file/0-base64/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-file/0-base64/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Returns the content of the file as base64 encoded string.
 
 ----
 
+Return:
+
+type: string
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-file/0-data-uri/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-file/0-data-uri/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Returns a full base64 encoded data uri with a proper mime type.
 
 ----
 
+Return:
+
+type: string
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-file/0-delete/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-file/0-delete/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Deletes the file. This cannot be undone.
 
 ----
 
+Return:
+
+type: boolean
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-file/0-dimensions/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-file/0-dimensions/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Returns the $dimensions object for the file. This is only available for images (
 
 ----
 
+Return:
+
+type: $dimension
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-file/0-dir/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-file/0-dir/cheatsheet.item.txt
@@ -6,6 +6,13 @@ Excerpt: Returns the full path for the directory, in which the file is located
 
 ----
 
+Return:
+
+type: string
+text:
+
+----
+
 Text:
 
 ## Example:

--- a/content/1-docs/9-cheatsheet/0-file/0-download/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-file/0-download/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Sends all needed headers and the content to force the browser to download the fi
 
 ----
 
+Return:
+
+type:
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-file/0-exif/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-file/0-exif/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Returns the $exif object for the file, which can be used to fetch information su
 
 ----
 
+Return:
+
+type: $exif
+text:
+
+----
+
 Text:
 
 ## Example
@@ -32,4 +39,3 @@ if($exif) {
 }
 
 ```
-

--- a/content/1-docs/9-cheatsheet/0-file/0-extension/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-file/0-extension/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Returns the file extension
 
 ----
 
+Return:
+
+type: string
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-file/0-filename/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-file/0-filename/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Returns the full filename including extension
 
 ----
 
+Return:
+
+type: string
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-file/0-has-next/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-file/0-has-next/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Checks if there's a next sibling
 
 ----
 
+Return:
+
+type: boolean
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-file/0-has-prev/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-file/0-has-prev/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Checks if there's a previous sibling
 
 ----
 
+Return:
+
+type: boolean
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-file/0-hash/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-file/0-hash/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Returns an md5 hash for the root of the file.
 
 ----
 
+Return:
+
+type: string
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-file/0-height/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-file/0-height/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Returns the height of image files in pixels
 
 ----
 
+Return:
+
+type: integer
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-file/0-is-landscape/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-file/0-is-landscape/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Checks if an image file has been taken in landscape mode.
 
 ----
 
+Return:
+
+type: boolean
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-file/0-is-portrait/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-file/0-is-portrait/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Checks if an image file has been taken in portrait mode.
 
 ----
 
+Return:
+
+type: boolean
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-file/0-is-readable/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-file/0-is-readable/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Checks if the file is readable
 
 ----
 
+Return:
+
+type: boolean
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-file/0-is-square/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-file/0-is-square/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Checks if the image is square
 
 ----
 
+Return:
+
+type: boolean
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-file/0-is-writable/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-file/0-is-writable/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Checks if the file is writable
 
 ----
 
+Return:
+
+type: boolean
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-file/0-mime/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-file/0-mime/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Returns the file's mime type
 
 ----
 
+Return:
+
+type: string
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-file/0-modified/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-file/0-modified/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Returns the unix timestamp or a formatted date for when the file has been modifi
 
 ----
 
+Return:
+
+type: integer | string
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-file/0-name/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-file/0-name/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Returns the name of the file without extension
 
 ----
 
+Return:
+
+type: string
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-file/0-next/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-file/0-next/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Returns the next sibling
 
 ----
 
+Return:
+
+type: $file
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-file/0-niceSize/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-file/0-niceSize/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Returns the size of the file in a human readable format.
 
 ----
 
+Return:
+
+type: string
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-file/0-orientation/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-file/0-orientation/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Returns the orientation of image files as a string (landscape, portrait, square)
 
 ----
 
+Return:
+
+type: string
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-file/0-prev/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-file/0-prev/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Returns the previous sibling
 
 ----
 
+Return:
+
+type: $file
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-file/0-ratio/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-file/0-ratio/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Returns the ratio of an image file
 
 ----
 
+Return:
+
+type: float
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-file/0-read/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-file/0-read/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Reads the content of a file and returns it
 
 ----
 
+Return:
+
+type: string
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-file/0-rename/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-file/0-rename/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Renames the file and all the meta text files.
 
 ----
 
+Return:
+
+type: string
+text: Returns the new filename.
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-file/0-root/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-file/0-root/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Returns the full root for a file
 
 ----
 
+Return:
+
+type: string
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-file/0-siblings/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-file/0-siblings/cheatsheet.item.txt
@@ -1,15 +1,20 @@
-Title: 
+Title:
 
 $file->siblings()
 
 ----
 
-Text: 
+Excerpt:
 
-
+Returns all siblings of the file.
 
 ----
 
-Excerpt: 
+Return:
 
-Returns all siblings of the file.
+type: $files
+text:
+
+----
+
+Text:

--- a/content/1-docs/9-cheatsheet/0-file/0-size/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-file/0-size/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Returns the raw file size
 
 ----
 
+Return:
+
+type: integer
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-file/0-type/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-file/0-type/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Returns the file type (image, document, video, archive, code, audio, unkown)
 
 ----
 
+Return:
+
+type: string
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-file/0-update/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-file/0-update/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Updates the meta information for a file
 
 ----
 
+Return:
+
+type: boolean
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-file/0-url/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-file/0-url/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Returns the absolute URL for a file.
 
 ----
 
+Return:
+
+type: string
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-file/0-width/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-file/0-width/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Returns the width of image files in pixels
 
 ----
 
+Return:
+
+type: integer
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-files/0-count/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-files/0-count/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Returns the number of files in the collection
 
 ----
 
+Return:
+
+type: integer
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-files/0-filter/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-files/0-filter/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Applies a filter callback to each item in the collection
 
 ----
 
+Return:
+
+type: $files
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-files/0-filterBy/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-files/0-filterBy/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Filters the collection by a key and value.
 
 ----
 
+Return:
+
+type: $files
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-files/0-find/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-files/0-find/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Finds a single file or multiple files by one or many filenames.
 
 ----
 
+Return:
+
+type: $file | $files
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-files/0-findBy/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-files/0-findBy/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Finds a single file by key and value
 
 ----
 
+Return:
+
+type: $file
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-files/0-first/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-files/0-first/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Returns the first file in the collection
 
 ----
 
+Return:
+
+type: $file
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-files/0-flip/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-files/0-flip/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Returns the collection in reverse order
 
 ----
 
+Return:
+
+type: $files
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-files/0-get/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-files/0-get/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Returns a single file by filename
 
 ----
 
+Return:
+
+type: $file
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-files/0-groupBy/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-files/0-groupBy/cheatsheet.item.txt
@@ -1,14 +1,20 @@
-Title: 
+Title:
 
 $files->groupBy($field, $caseInsensitive = true)
 
 ----
 
-Excerpt: 
+Excerpt:
 
 Groups all files in the collection by a given field.
 
 ----
 
-Text: 
+Return:
 
+type: $files
+text:
+
+----
+
+Text:

--- a/content/1-docs/9-cheatsheet/0-files/0-keys/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-files/0-keys/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Returns an array with all filenames in the collection.
 
 ----
 
+Return:
+
+type: array
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-files/0-last/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-files/0-last/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Returns the last file in the collection
 
 ----
 
+Return:
+
+type: $file
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-files/0-limit/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-files/0-limit/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Returns the collection with a limited set of items
 
 ----
 
+Return:
+
+type: $files
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-files/0-map/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-files/0-map/cheatsheet.item.txt
@@ -1,14 +1,20 @@
-Title: 
+Title:
 
 $files->map($callback)
 
 ----
 
-Excerpt: 
+Excerpt:
 
 Applies a callback to all items in the collection.
 
 ----
 
-Text: 
+Return:
 
+type: $files
+text:
+
+----
+
+Text:

--- a/content/1-docs/9-cheatsheet/0-files/0-not/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-files/0-not/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Returns the collection without a given file. The ignored file can be passed by f
 
 ----
 
+Return:
+
+type: $files
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-files/0-nth/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-files/0-nth/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Returns the nth file in the collection.
 
 ----
 
+Return:
+
+type: $file
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-files/0-offset/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-files/0-offset/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Returns the collection starting from a given offset
 
 ----
 
+Return:
+
+type: $files
+text:
+
+----
+
 Text:
 
 ## Example
@@ -25,4 +32,3 @@ Text:
   <?php endforeach ?>
 </ul>
 ```
-

--- a/content/1-docs/9-cheatsheet/0-files/0-paginate/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-files/0-paginate/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Applies pagination to the collection
 
 ----
 
+Return:
+
+type: $files
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-files/0-pagination/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-files/0-pagination/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Returns the $pagination object
 
 ----
 
+Return:
+
+type: $pagination
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-files/0-pluck/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-files/0-pluck/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Plucks all values for a specific field from the collection and returns those as 
 
 ----
 
+Return:
+
+type: array
+text:
+
+----
+
 Text:
 
 ## Example
@@ -21,4 +28,3 @@ Text:
   <?php endforeach ?>
 </ul>
 ```
-

--- a/content/1-docs/9-cheatsheet/0-files/0-shuffle/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-files/0-shuffle/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Returns the collection in shuffled order.
 
 ----
 
+Return:
+
+type: $files
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-files/0-slice/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-files/0-slice/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Returns a sliced version of the collection starting from a given offset and an o
 
 ----
 
+Return:
+
+type: $files
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-files/0-sortBy/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-files/0-sortBy/cheatsheet.item.txt
@@ -10,6 +10,13 @@ Sorts the files in the collection by field and direction
 
 ----
 
+Return:
+
+type: $files
+text:
+
+----
+
 Text:
 
 ```php

--- a/content/1-docs/9-cheatsheet/0-files/0-to-array/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-files/0-to-array/cheatsheet.item.txt
@@ -1,14 +1,20 @@
-Title: 
+Title:
 
 $files->toArray($callback = null)
 
 ----
 
-Excerpt: 
+Excerpt:
 
 Converts the collection to a simple array.
 
 ----
 
-Text: 
+Return:
 
+type: array
+text:
+
+----
+
+Text:

--- a/content/1-docs/9-cheatsheet/0-files/0-to-json/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-files/0-to-json/cheatsheet.item.txt
@@ -1,14 +1,20 @@
-Title: 
+Title:
 
 $files->toJson()
 
 ----
 
-Excerpt: 
+Excerpt:
 
 Converts the collection to a json string.
 
 ----
 
-Text: 
+Return:
 
+type: string
+text:
+
+----
+
+Text:

--- a/content/1-docs/9-cheatsheet/0-helpers/0-attr/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-helpers/0-attr/cheatsheet.item.txt
@@ -6,6 +6,13 @@ Excerpt: Creates attributes for an html tag
 
 ----
 
+Return:
+
+type: $brick
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-helpers/0-brick/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-helpers/0-brick/cheatsheet.item.txt
@@ -6,6 +6,13 @@ Excerpt: Creates an HTML Element (Brick object)
 
 ----
 
+Return:
+
+type: $brick
+text:
+
+----
+
 Text:
 
 ## Example
@@ -46,5 +53,3 @@ $figure->append(function() {
 echo $figure;
 
 ```
-
-

--- a/content/1-docs/9-cheatsheet/0-helpers/0-css/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-helpers/0-css/cheatsheet.item.txt
@@ -6,6 +6,13 @@ Excerpt: Creates one or multiple css link tags
 
 ----
 
+Return:
+
+type: string
+text:
+
+----
+
 Text:
 
 ## Example
@@ -40,4 +47,3 @@ Template                    | CSS file
 /site/templates/project.php | /assets/css/templates/project.css
 /site/templates/home.php    | /assets/css/templates/home.css
 /site/templates/blog.php    | /assets/css/templates/blog.css
-

--- a/content/1-docs/9-cheatsheet/0-helpers/0-dump/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-helpers/0-dump/cheatsheet.item.txt
@@ -6,6 +6,13 @@ Excerpt: Dumps the content of any variable in a human readable way for debugging
 
 ----
 
+Return:
+
+type: string
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-helpers/0-e/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-helpers/0-e/cheatsheet.item.txt
@@ -6,6 +6,13 @@ Excerpt: Echos one of two alternatives depending on a condition (Shortcut for ec
 
 ----
 
+Return:
+
+type: echo
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-helpers/0-ecco/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-helpers/0-ecco/cheatsheet.item.txt
@@ -6,6 +6,13 @@ Excerpt: Echos one of two alternatives depending on a condition
 
 ----
 
+Return:
+
+type: echo
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-helpers/0-email/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-helpers/0-email/cheatsheet.item.txt
@@ -6,6 +6,13 @@ Excerpt: Sends an email
 
 ----
 
+Return:
+
+type: $email
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-helpers/0-excerpt/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-helpers/0-excerpt/cheatsheet.item.txt
@@ -6,6 +6,13 @@ Excerpt: Creates an excerpt of any text by a given character length
 
 ----
 
+Return:
+
+type: string
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-helpers/0-get/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-helpers/0-get/cheatsheet.item.txt
@@ -6,6 +6,13 @@ Excerpt: Fetches a POST or GET parameter by key
 
 ----
 
+Return:
+
+type: string
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-helpers/0-gist/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-helpers/0-gist/cheatsheet.item.txt
@@ -6,6 +6,13 @@ Excerpt: Embeds a Gist from Github by URL
 
 ----
 
+Return:
+
+type: string
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-helpers/0-go/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-helpers/0-go/cheatsheet.item.txt
@@ -6,6 +6,13 @@ Excerpt: Redirects to a different URL
 
 ----
 
+Return:
+
+type: 
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-helpers/0-gravatar/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-helpers/0-gravatar/cheatsheet.item.txt
@@ -6,6 +6,13 @@ Excerpt: Builds the Gravatar URL by email
 
 ----
 
+Return:
+
+type: string
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-helpers/0-h/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-helpers/0-h/cheatsheet.item.txt
@@ -6,6 +6,13 @@ Excerpt: Converts any text to valid HTML (shortcut for html())
 
 ----
 
+Return:
+
+type: string
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-helpers/0-html/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-helpers/0-html/cheatsheet.item.txt
@@ -6,6 +6,13 @@ Excerpt: Converts any text to valid HTML
 
 ----
 
+Return:
+
+type: string
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-helpers/0-invalid/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-helpers/0-invalid/cheatsheet.item.txt
@@ -6,6 +6,13 @@ Excerpt: Runs a number of validators on a set of data and checks if the data is 
 
 ----
 
+Return:
+
+type: array
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-helpers/0-js/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-helpers/0-js/cheatsheet.item.txt
@@ -6,6 +6,13 @@ Excerpt: Creates a script tag to load a javascript file
 
 ----
 
+Return:
+
+type: string
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-helpers/0-kirbytag/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-helpers/0-kirbytag/cheatsheet.item.txt
@@ -6,6 +6,13 @@ Excerpt: Makes it possible to use any defined kirbytag as standalone function
 
 ----
 
+Return:
+
+type: string
+text:
+
+----
+
 Text:
 
 ```php

--- a/content/1-docs/9-cheatsheet/0-helpers/0-kirbytext/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-helpers/0-kirbytext/cheatsheet.item.txt
@@ -6,6 +6,13 @@ Excerpt: Parses any text with Markdown and Kirbytext
 
 ----
 
+Return:
+
+type: string
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-helpers/0-l/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-helpers/0-l/cheatsheet.item.txt
@@ -6,6 +6,13 @@ Excerpt: Fetches a language variable for multi-language sites
 
 ----
 
+Return:
+
+type: string
+text:
+
+----
+
 Text:
 
 For multi-language sites you can set custom language variables in `/site/languages`. Create a language file for each available language.

--- a/content/1-docs/9-cheatsheet/0-helpers/0-markdown/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-helpers/0-markdown/cheatsheet.item.txt
@@ -6,6 +6,13 @@ Excerpt: Parses the text as Markdown
 
 ----
 
+Return:
+
+type: string
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-helpers/0-multiline/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-helpers/0-multiline/cheatsheet.item.txt
@@ -6,6 +6,13 @@ Excerpt: Converts new lines in text to html breaks.
 
 ----
 
+Return:
+
+type: string
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-helpers/0-page/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-helpers/0-page/cheatsheet.item.txt
@@ -6,6 +6,13 @@ Excerpt: Fetches any page by URI or the current page when no URI is specified
 
 ----
 
+Return:
+
+type: $page
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-helpers/0-param/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-helpers/0-param/cheatsheet.item.txt
@@ -6,6 +6,13 @@ Excerpt: Fetches a Kirby URL parameter
 
 ----
 
+Return:
+
+type: string
+text:
+
+----
+
 Text:
 
 Additional to URL query variables you can set parameters via URL in Kirby in a more human readable way:

--- a/content/1-docs/9-cheatsheet/0-helpers/0-r/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-helpers/0-r/cheatsheet.item.txt
@@ -6,6 +6,13 @@ Excerpt: Returns either $a or $b by the given condition
 
 ----
 
+Return:
+
+type: any
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-helpers/0-site/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-helpers/0-site/cheatsheet.item.txt
@@ -6,6 +6,13 @@ Excerpt: Returns the site object in any situation
 
 ----
 
+Return:
+
+type: $site
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-helpers/0-size/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-helpers/0-size/cheatsheet.item.txt
@@ -2,7 +2,14 @@ Title: size($input)
 
 ----
 
-Excerpt: Returns the size of strings, numbers and files.
+Excerpt: Returns the size of strings, numbers, files and arrays.
+
+----
+
+Return:
+
+type: integer
+text:
 
 ----
 

--- a/content/1-docs/9-cheatsheet/0-helpers/0-thumb/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-helpers/0-thumb/cheatsheet.item.txt
@@ -6,6 +6,13 @@ Excerpt: Creates a thumbnail for a given image object
 
 ----
 
+Return:
+
+type: $thumb
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-helpers/0-twitter/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-helpers/0-twitter/cheatsheet.item.txt
@@ -6,6 +6,13 @@ Excerpt: Builds a Twitter profile link by username
 
 ----
 
+Return:
+
+type: string
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-helpers/0-u/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-helpers/0-u/cheatsheet.item.txt
@@ -6,6 +6,13 @@ Excerpt: Shortcut for url()
 
 ----
 
+Return:
+
+type: string
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-helpers/0-url/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-helpers/0-url/cheatsheet.item.txt
@@ -6,6 +6,13 @@ Excerpt: Builds an absolute URL for a given path
 
 ----
 
+Return:
+
+type: string
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-helpers/0-vimeo/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-helpers/0-vimeo/cheatsheet.item.txt
@@ -6,6 +6,13 @@ Excerpt: Embeds a Vimeo video by URL
 
 ----
 
+Return:
+
+type: string
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-helpers/0-widont/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-helpers/0-widont/cheatsheet.item.txt
@@ -6,6 +6,13 @@ Excerpt: Avoids typographical widows in strings by replacing the last space with
 
 ----
 
+Return:
+
+type: string
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-helpers/0-xml/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-helpers/0-xml/cheatsheet.item.txt
@@ -6,6 +6,13 @@ Excerpt: Converts any text to valid XML
 
 ----
 
+Return:
+
+type: string
+text:
+
+----
+
 Text:
 
 ## Example

--- a/content/1-docs/9-cheatsheet/0-helpers/0-yaml/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-helpers/0-yaml/cheatsheet.item.txt
@@ -6,6 +6,13 @@ Excerpt: Parses any string as YAML
 
 ----
 
+Return:
+
+type: array
+text:
+
+----
+
 Text:
 
 You can store structured data in fields with YAML. YAML is a simple structuring syntax, which is easy to understand and use.

--- a/content/1-docs/9-cheatsheet/0-helpers/0-youtube/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-helpers/0-youtube/cheatsheet.item.txt
@@ -6,6 +6,13 @@ Excerpt: Embeds a Youtube video by URL
 
 ----
 
+Return:
+
+type: string
+text:
+
+----
+
 Text:
 
 ## Example


### PR DESCRIPTION
__0-field-methods__
* length() returns string (comments in toolkit/lib/str.php) or integer (because strlen returns integer)?
* or() does return "any" type - maybe you want to change it, or explain in the return text?
* words() returns an array of strings (toolkit/lib/str.php) or integer like in the description?

__0-fiele__
* dimensions() returns "$dimensions" type, but its called "$dimension" in 0-dimension. what do you prefer? (regarding the plural form in eg $pages is a collection of $page objects - I think the singular $dimension is more appropriate)
* What exactly does download() return?

__0-helpers__
* brick() & attr() return $brick (and string)?
* e() & ecco() return "echo"?
* email() returns $email?
* What exactly does go() return?
* r() returns "any"?
* thumb() returns $thumb?