### PR TITLE
Correct mistake in docs

### DIFF
--- a/content/1-docs/4-templates/3-api/docs.txt
+++ b/content/1-docs/4-templates/3-api/docs.txt
@@ -12,7 +12,7 @@ Kirby has a might API, which you can use in your snippets, templates and plugins
 
 This section is about to give you a good overview of the most basic things you can do with the API. If you want to dive deeper you can find a full overview of all available API methods on the cheat sheet.
 
-All parts of the API are inspired by the simplicity of jQuery. When you've played with jQuery before you will probably feel at home at once — even if it is PHP.
+All parts of the API are inspired by the simplicity of jQuery. If you've played with jQuery before you will probably feel at home at once — even if it is PHP.
 
 ## $site
 


### PR DESCRIPTION
I think I've spotted a mistake in the docs. The author uses *when* even when the function of that clause is clearly conditional... that's probably due to the fact that *wenn* can mean *if* in German :)