### PR TITLE
add docs for auto language detection in language setup

### DIFF
--- a/content/1-docs/6-languages/0-setup/docs.txt
+++ b/content/1-docs/6-languages/0-setup/docs.txt
@@ -32,4 +32,12 @@ c::set('languages', array(
 ));
 ```
 
-As soon as more than one languages are setup in the languages array, multi-language support is switched on automatically.
+As soon as more than one languages are setup in the languages array, multi-language support is switched on.
+
+### Automatic Language Detection
+
+Kirby can detect the prefered language of the visitor. This has to be activated by adding:
+
+```php
+c::set('language.detect', true);
+```


### PR DESCRIPTION
I made the mistake of assuming that setting up the languages in Kirby v2 will activate auto-detection. This bit of information would have helped me.

I later found out that the option is listed in Advanced/Options, but only after learning how it works by opening a support ticket.