### PR TITLE
Fix for #45: Cheatsheet/Toolkit API items have correct title and urls

### DIFF
--- a/content/1-docs/4-templates/3-api/docs.txt
+++ b/content/1-docs/4-templates/3-api/docs.txt
@@ -8,7 +8,7 @@ Description: Learn the basics about Kirby's extensive API and how to use it to b
 
 Text:
 
-Kirby has a might API, which you can use in your snippets, templates and plugins to access each and every bit and piece of data and aspect of your site and system.
+Kirby has a mighty API, which you can use in your snippets, templates and plugins to access each and every bit and piece of data and aspect of your site and system.
 
 This section is about to give you a good overview of the most basic things you can do with the API. If you want to dive deeper you can find a full overview of all available API methods on the cheat sheet.
 

--- a/site/templates/cheatsheet.item.php
+++ b/site/templates/cheatsheet.item.php
@@ -46,8 +46,13 @@
     </section>
 
     <nav class="sidebar col-2-6 last">
+      <?php $overview_page = page((string)kirby()->request()->path()->slice(0, -2)) ?>
       <ul>
-        <li><a href="<?php echo url((string)kirby()->request()->path()->slice(0, 2)) ?>"><small>&uarr;</small>Cheat Sheet overview</a></li>
+        <li>
+          <a href="<?php echo $overview_page->url() ?>">
+            <small>&uarr;</small><?php echo $overview_page->title() ?> overview
+          </a>
+        </li>
 
         <?php if($prev = $page->prevVisible()): ?>
         <li><a href="<?php echo $prev->url() ?>"><small>&larr;</small> <?php echo html($prev->title()) ?></a></li>
@@ -57,7 +62,11 @@
         <li><a href="<?php echo $next->url() ?>"><small>&rarr;</small> <?php echo html($next->title()) ?></a></li>
         <?php endif ?>
 
-        <li><a href="<?php echo url((string)kirby()->request()->path()->slice(0, 2)) ?>#<?php echo $page->parent()->uid() ?>"><small>&darr;</small>Back to Cheat Sheet section</a></li>
+        <li>
+          <a href="<?php echo $overview_page->url() ?>#<?php echo $page->parent()->uid() ?>">
+            <small>&darr;</small>Back to <?php echo $overview_page->title() ?> section
+          </a>
+        </li>
       </ul>
     </nav>
 


### PR DESCRIPTION
Ideally I think the `cheatsheat.item.php` template should be moved to a more generic template like perhaps `api.item.php`, since the Cheat Sheet page's `cheatsheet.php` template has just been re-used for the Toolkit API page.

I'm proposing this simple solution till that refactor occurs (if it ever does).