### PR TITLE
Fix for #31: Fix autocomplete links by making them absolute uri's on navigation

### DIFF
--- a/assets/js/templates/docs.index.js
+++ b/assets/js/templates/docs.index.js
@@ -1,5 +1,5 @@
 // Add section anchors to every <h2> + <h3> within docs
 
 $('#q').autocomplete().on('autocomplete:add', function(e, item) {
-  window.location.href = item.uri;
+    window.location.href = "/" + item.uri;
 });


### PR DESCRIPTION
The problem:
- When a user clicks on any of the autocomplete results, the window attempts to redirect using the relative URI provided. This causes issues if the user is on a page that has a URL with a trailing `/`.

I considered solving this by simply changing the autocomplete results to use page URLs instead of relative URIs, but that solution is visibly unappealing:

Relative paths:
![screen shot 2015-03-11 at 7 10 05 pm](https://cloud.githubusercontent.com/assets/587136/6604730/91ff6ef6-c850-11e4-9f30-3687101af008.png)

Absolute URLs:
![screen shot 2015-03-11 at 7 10 46 pm](https://cloud.githubusercontent.com/assets/587136/6604736/9d80baa0-c850-11e4-9484-20299e5010ab.png)

I also didn't want to have the `docs.json` cache contain a URL field _and_ a URI field per item. That just feels like a waste of space for what we're trying to solve.

Hence I arrived at this slightly duct-tapey solution. I've tested it with on both pages with and without the trailing "/" and it seems to work pretty well.

Let me know what you guys think.
