### PR TITLE
correct documentation for request()->ajax() and v::same()

### DIFF
--- a/content/1-docs/9-cheatsheet/0-request/0-ajax/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-request/0-ajax/cheatsheet.item.txt
@@ -17,6 +17,6 @@ Text:
 
 ```php
 if(kirby()->request()->ajax()) {
-  echo 'This is an ajax request'
+  echo 'This is an ajax request';
 }
 ```

--- a/content/1-docs/9-cheatsheet/0-validators/0-same/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-validators/0-same/cheatsheet.item.txt
@@ -18,7 +18,7 @@ Text:
 ## In your code
 
 ```php
-if(v::equals('A', 'A')) {
+if(v::same('A', 'A')) {
   echo 'Yay, valid!';
 }
 


### PR DESCRIPTION
added missing semicolon for request()->ajax() example
changed v::equals() to v::same()