### PR TITLE
[Hep wanted] Start page model docs

### DIFF
--- a/content/1-docs/4-templates/5-models/docs.txt
+++ b/content/1-docs/4-templates/5-models/docs.txt
@@ -1,0 +1,102 @@
+Title: Page Models
+
+----
+
+Description: Learn how to extend the page class to override it with custom functionality.
+
+----
+
+Text:
+
+(toc)
+
+Templates should contain as little code as possible to separate logic and form. With template controllers you can add more logic to your templates without messing up your markup.
+
+## The models directory
+
+Page models go into `/site/models`. Please create the directory if it's not there yet. Page models are named exactly like the templates they belong to:
+
+Template | Page model
+-        | -
+/site/templates/article.php | /site/models/article.php
+
+Kirby will automatically load the page model for your template if it can find one.
+
+## Creating a page model
+
+The basic code for a page model is very simple. It is a PHP class extending Kirby's internal `Page` class. Page models follow the same naming conventions as templates and controllers. If your content file is called `project.txt`, Kirby will look for a class `ProjectPage` and load it automatically, if it finds one.
+
+```php
+<?php
+
+// For a content file called `project.txt`
+// In general the class name is {{ProjectFileName}}Page
+
+class ProjectPage extends Page {
+    // all methods of the Page class are inherited and can be overridden here now.
+}
+```
+
+This page model will be loaded every time Kirby encounters a page of the given type (so `project` in this example), whether it is in a template, a snippet or anywhere else.
+
+
+## A real world example
+
+A typical example when a page model can come in handy is a featured projects section on your home page. Image you want to present your past projects with a nice featured image. Fetching the right image in the template or snippet can be a couple of lines of code. It is way cleaner to seperate this functionality into a page model. So let's create the snippet in `site/snippets/projects.php` and the page model in `site/models/project.php`. 
+
+### The page model
+
+The page model will make a method called `coverImage()` available for all your project pages. It will return the cover image, so you don't have to fetch it in the template code.
+
+```php
+<?php
+
+class ProjectModel extends Page {
+
+    public function coverImage() {
+        return $this->images()->sortBy('sort', 'ASC')->first();
+    }
+}
+```
+
+Note, that you're using `$this` where you would usually use `$page` anywhere else in Kirby. 
+
+### The snippet
+
+With such a page model, the snippet can be super clean. 
+
+```php
+<h2>Latest Projects</h2>
+
+<ul>
+    <?php foreach(page('projects')->children()->visible()->limit(3) as $project): ?>
+    <li>
+        <h3><a href="<?php echo $project->url() ?>"><?php echo $project->title() ?></a></h3>
+        <?php if($image = $page->coverImage()): ?>
+            <img src="<?php echo $image->url() ?>" alt="<?php echo $project->title() ?>" />
+        <?php endif ?>
+    </li>
+    <?php endforeach ?>
+</ul>
+```
+
+By placing the code for selecting the cover image you don't have to repeat it in every single snippet and template in which you are dealing with projects. An additional benefit is that it becomes very easy to change what image you are selcting as a cover: By changing only one method you can consistently select the last image, one with a given file name or even a thumbnail. 
+
+## Overriding the Page class
+
+As a very advanced feature it is possible to override the functionality of Kirby's page class. Be careful with this as it is possible to change Kirby's behaviour in unwanted ways!
+
+In the example above you applied the `sortBy()` method to your images. If you're also sorting your images in your project template, you may override Kirby's `image()` method to return them sorted by default.
+
+```php
+<?php
+
+class ProjectPage extends Page {
+
+    public function images() {
+        return parent::images()->sortBy('sort', 'ASC');
+    }
+}
+```
+
+You created a function with the same name as one that existed already in the page class. Because your class extends the page class your method will be used instead of the default method whenever called on a project page. Please note the usage of `parent` instead of `$this`. If you are interested in  programming paradigms like inheritance and recursion, keep reading.


### PR DESCRIPTION
After seeing that there are still no docs on page models I decided to give it a swing. 

While the simple features like extending the page class are relatively easy to explain, I'm not sure how much to cover in the advanced section in the end. As a computer scientist I feel like I would have to explain inheritance, overriding and recursion. However, that might be overkill for CMS docs and better suited for an article about programming paradigms. 

This is very much a draft and I would be happy to hear your feedback and integrate some changes. 