### PR TITLE
Change `false` to `null` in $page->date() docs

### DIFF
--- a/content/1-docs/11-cheatsheet/0-page/0-date/cheatsheet.item.txt
+++ b/content/1-docs/11-cheatsheet/0-page/0-date/cheatsheet.item.txt
@@ -1,6 +1,6 @@
 Title:
 
-$page->date($format = false, $field = 'date')
+$page->date($format = null, $field = 'date')
 
 ----
 
@@ -50,5 +50,5 @@ By default the date method will return the Unix timestamp. You can use that to m
 ```
 
 ```php
-<?php echo strftime('%d/%m/%Y', $page->date(false, 'createdAt')) ?>
+<?php echo strftime('%d/%m/%Y', $page->date(null, 'createdAt')) ?>
 ```


### PR DESCRIPTION
Before getkirby/kirby@78473d149d42f4d9abe76981078b93ee62cff488, it didn't matter, but now it has to be `null`.