### PR TITLE
Fixed the code in the pagination doc page

### DIFF
--- a/content/1-docs/9-solutions/03-blog/05-pagination/docs.txt
+++ b/content/1-docs/9-solutions/03-blog/05-pagination/docs.txt
@@ -53,11 +53,11 @@ Add this below your foreach loop:
 <nav class="pagination">
 
   <?php if($articles->pagination()->hasNextPage()): ?>
-  <a class="next" href="<?php echo $articles->pagination()->nextPageURL() ?>">&lsaquo; newer posts</a>
+  <a class="next" href="<?php echo $articles->pagination()->nextPageURL() ?>">&lsaquo; older posts</a>
   <?php endif ?>
 
   <?php if($articles->pagination()->hasPrevPage()): ?>
-  <a class="prev" href="<?php echo $articles->pagination()->prevPageURL() ?>">older posts &rsaquo;</a>
+  <a class="prev" href="<?php echo $articles->pagination()->prevPageURL() ?>">newer posts &rsaquo;</a>
   <?php endif ?>
 
 </nav>


### PR DESCRIPTION
IMHO given that we "flip" the order of the articles (as in the example code) the nav links make more sense this way.