### PR TITLE
Add delimiters to regular expression of v::match

### DIFF
--- a/content/1-docs/11-cheatsheet/0-validators/0-match/cheatsheet.item.txt
+++ b/content/1-docs/11-cheatsheet/0-validators/0-match/cheatsheet.item.txt
@@ -18,7 +18,7 @@ Text:
 ## In your code
 
 ```php
-if(v::match($value, '[a-z0-9]+')) {
+if(v::match($value, '/[a-z0-9]+/')) {
   echo 'Yay, valid!';
 }
 
@@ -32,5 +32,5 @@ fields:
     label: Example field
     type: text
     validate:
-      match: [a-z0-9]+
+      match: "/[a-z0-9]+/"
 ```


### PR DESCRIPTION
Without delimiters `preg_match` will fail recognizing the regular expression.