### PR TITLE
Fix for #280: Broken Link 

### DIFF
--- a/content/1-docs/7-developer-guide/4-advanced/7-emails/docs.txt
+++ b/content/1-docs/7-developer-guide/4-advanced/7-emails/docs.txt
@@ -130,7 +130,7 @@ foreach($listOfRecipients as $recipient) {
 
 ## Configuration
 
-You can (link: docs/developer-guide/configuration/email text: configure all email options) in your Kirby config file. 
+You can (link: docs/cheatsheet/helpers/email text: configure all email options) in your Kirby config file. 
 
 ## Write your own email driver
 


### PR DESCRIPTION
I assumed that the correct link is docs/cheatsheet/helpers/email

Original: You can (link: docs/developer-guide/configuration/email text: configure all email options) in your Kirby config file. 
