### PR TITLE
Update csrf() helper docs

### DIFF
--- a/content/1-docs/10-toolkit/1-api/0-helpers/0-csrf/cheatsheet.item.txt
+++ b/content/1-docs/10-toolkit/1-api/0-helpers/0-csrf/cheatsheet.item.txt
@@ -34,7 +34,7 @@ Text:
 
 ```php
 $token = get('csrf');
-if(csrf($token)) {
+if(csrf($token) === true) {
   // Success
 } else {
   // Token doesn't match


### PR DESCRIPTION
The csrf() helper returns the CSRF token if it is called the first time. If the developer forgot to add the CSRF form field, the helper will return the token in the if condition, which evaluates to true. That's obviously not what we want so we should do a strict check here.