### PR TITLE
Clarify how to pass URL params with remote::get method

### DIFF
--- a/content/1-docs/10-toolkit/1-api/0-remote/0-get/cheatsheet.item.txt
+++ b/content/1-docs/10-toolkit/1-api/0-remote/0-get/cheatsheet.item.txt
@@ -6,6 +6,20 @@ Excerpt: Static method to send a GET request
 
 ----
 
+Text:
+
+The supplied `$params` are merged with the [default GET request arguments](https://github.com/getkirby/toolkit/blob/master/lib/remote.php#L206-L209), which means any URL _query parameters_ should be passed as a `data` key:
+
+```php
+$response = remote::get('https://baseurl.com', [
+  'data' => [
+    'param' => 'val'
+  ]
+]);
+```
+
+----
+
 Call: remote::get($url, $params = array())
 
 ----

--- a/content/1-docs/10-toolkit/1-api/0-remote/0-get/cheatsheet.item.txt
+++ b/content/1-docs/10-toolkit/1-api/0-remote/0-get/cheatsheet.item.txt
@@ -8,7 +8,11 @@ Excerpt: Static method to send a GET request
 
 Text:
 
-The supplied `$params` are merged with the [default GET request arguments](https://github.com/getkirby/toolkit/blob/master/lib/remote.php#L206-L209), which means any URL _query parameters_ should be passed as a `data` key:
+## Example
+
+### Query Parameters
+
+Pass query parameters by providing a `data` key in the `$params` argument:
 
 ```php
 $response = remote::get('https://baseurl.com', [
@@ -16,6 +20,8 @@ $response = remote::get('https://baseurl.com', [
     'param' => 'val'
   ]
 ]);
+
+// -> GET https://baseurl.com?param=val
 ```
 
 ----


### PR DESCRIPTION
Pretty simple docs update.

`remote::get` is not particularly debuggable, and I couldn't figure out why my query params weren't being passed— turns out the `$params` argument isn't directly passed as query params to the URL, but merged with the defaults, from which the `data` key is picked and transformed into the query string.

👍 