### PR TITLE
Typo kirbext() on line #21 ?

### DIFF
--- a/content/1-docs/9-cheatsheet/0-field-methods/0-words/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-field-methods/0-words/cheatsheet.item.txt
@@ -18,7 +18,7 @@ Text:
 ## Example
 
 ```php
-<?= $page->text()->kirbext() ?>
+<?= $page->text()->kirbytext() ?>
 
 <dl class="text-stats">
 


### PR DESCRIPTION
I think that line #21 "<?= $page->text()->kirbext() ?>" should read "<?= $page->text()->kirbytext() ?>"?