### PR TITLE
Update cheatsheet.item.txt

### DIFF
--- a/content/1-docs/9-cheatsheet/0-panel-fields/0-email/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-panel-fields/0-email/cheatsheet.item.txt
@@ -44,16 +44,14 @@ However, if you want to make use of Kirby's built-in email obfuscation, you have
 Using `html::email()`:
 
 ```php
-<a href="mailto:<?= html::email($site->email()) ?>">
-    <?php echo html::email($site->email()) ?>
-</a>
+<?= html::email($page->email()) ?>
 ```
 
 Using `str::encode()`:
 
 ```php
-<a href="mailto:<?= str::encode($site->email()) ?>">
-    <?= str::encode($site->email()) ?>
+<a href="mailto:<?= str::encode($page->email()) ?>">
+    <?= str::encode($page->email()) ?>
 </a>
 ````
 
@@ -61,7 +59,7 @@ Using the `kirbytag()` helper:
 
 ```php
 <?= kirbytag([
-      'email'  => $site->email(),
+      'email'  => $page->email(),
       'text'  => 'Contact us'
     ]);
 ?>


### PR DESCRIPTION
Hi there,
1) If I follow the example "Using `html::email()`:" the '"mailto:' and '">' seem redundant as '<?= html::email($page->email()) ?>' seems to generate the complete code required. Example, in my template I have just:
```
<?= html::email($page->lada_event_contact_email()) ?>
```
and this outputs:
```
<a href="mailto:steve@steveoddy.com">steve@steveoddy.com</a>
```

2) I think it would be more consistant if all the examples used `$page->email()`rather than a mixture with `$site->email()`.

3) The link to the image at the bottom of the page ** Result** seems to be broken.

https://getkirby.com/docs/cheatsheet/panel-fields/email

Cheers,

Steve.