### PR TITLE
Add a template example to cheatsheet/panel-fields/tel

### DIFF
--- a/content/1-docs/9-cheatsheet/0-panel-fields/0-tel/cheatsheet.item.txt
+++ b/content/1-docs/9-cheatsheet/0-panel-fields/0-tel/cheatsheet.item.txt
@@ -20,3 +20,11 @@ fields:
     label: Phone
     type: tel
 ```
+
+## In your templates
+
+You can create `tel` links in your templates like this:
+
+```
+<?= html::a("tel:" . $page->phone(), $page->phone()) ?>
+```


### PR DESCRIPTION
On the page:

https://getkirby.com/docs/cheatsheet/panel-fields/email

there is an example of how to get an email field in a template (heading "In your templates").

Would it be useful to add a similar heading for the "tel" field?

Cheers,

Steve.