### PR TITLE
Controller Example: Add pagination after filter

### DIFF
--- a/content/1-docs/7-developer-guide/4-advanced/4-controllers/docs.txt
+++ b/content/1-docs/7-developer-guide/4-advanced/4-controllers/docs.txt
@@ -53,13 +53,16 @@ The controller will take care of fetching the right articles and add pagination 
 
 return function($site, $pages, $page) {
 
-  // get all articles and add pagination
-  $articles = $page->children()->visible()->flip()->paginate(20);
+  // get all articles
+  $articles = $page->children()->visible()->flip();
 
   // add a tag filter
   if($tag = param('tag')) {
     $articles = $articles->filterBy('tags', '=', urldecode($tag), ',');
   }
+  
+  // add pagination
+  $articles = $articles->paginate(20);
 
   // create a shortcut for pagination
   $pagination = $articles->pagination();


### PR DESCRIPTION
The pagination have to add after the filter. In the current example the pagination object has the values before the filter. 

Therefore the functions for the total number of items or the total pages return the values without the filter.

Add the pagination after the filter will fix it.