### PR TITLE
Hide deprecated and internal methods in reference

### DIFF
--- a/site/plugins/site/src/Models/ClassPage.php
+++ b/site/plugins/site/src/Models/ClassPage.php
@@ -62,7 +62,12 @@ class ClassPage extends Page
             ];
         }
 
-        return $this->children = Pages::factory($children, $this)->sortBy('slug');
+        $pages = Pages::factory($children, $this)
+                    ->sortBy('slug')
+                    ->filterBy('methodExists', true)
+                    ->filterBy('methodHidden', false);
+
+        return $this->children = $pages;
     }
 
     public function classExists(): bool
@@ -165,11 +170,6 @@ class ClassPage extends Page
         }
 
         return false;
-    }
-
-    public function methods()
-    {
-        return $this->children()->filterBy('methodExists', true);
     }
 
     public function missingMethods()

--- a/site/plugins/site/src/Models/ClassPage.php
+++ b/site/plugins/site/src/Models/ClassPage.php
@@ -63,9 +63,9 @@ class ClassPage extends Page
         }
 
         $pages = Pages::factory($children, $this)
-                    ->sortBy('slug')
                     ->filterBy('methodExists', true)
-                    ->filterBy('methodHidden', false);
+                    ->filterBy('methodHidden', false)
+                    ->sortBy('slug');
 
         return $this->children = $pages;
     }

--- a/site/plugins/site/src/Models/MethodPage.php
+++ b/site/plugins/site/src/Models/MethodPage.php
@@ -97,6 +97,23 @@ class MethodPage extends HelperPage
         return method_exists($this->className(), $this->methodName());
     }
 
+    public function methodHidden(): bool
+    {
+        if ($this->docBlock() === false) {
+            return false;
+        }
+
+        if (is_null($this->docBlock()->getTag('internal')) === false) {
+            return true;
+        }
+
+        if (is_null($this->docBlock()->getTag('deprecated')) === false) {
+            return true;
+        }
+
+        return false;
+    }
+
     public function methodScope()
     {
 


### PR DESCRIPTION
A first draft of how we could filter those methods using `@internal` and `@deprecated`.

Solves #137 
Solves #173 