### PR TITLE
sections extension: wrong context for this

### DIFF
--- a/content/1_docs/3_reference/7_plugins/1_extensions/0_sections/extension.txt
+++ b/content/1_docs/3_reference/7_plugins/1_extensions/0_sections/extension.txt
@@ -214,7 +214,7 @@ panel.plugin('yourname/modified', {
         }
       },
       created: function() {
-        this.load().then(function (response) {
+        this.load().then(response => {
           this.headline = response.headline;
           this.text     = response.text;
         });
@@ -241,7 +241,7 @@ panel.plugin('yourname/modified', {
         }
       },
       created: function() {
-        this.load().then(function (response) {
+        this.load().then(response => {
           this.headline = response.headline;
           this.text     = response.text;
         });


### PR DESCRIPTION
In the examples "this" is in the wrong context and therefore there is no output (and no error message). I suggest to use arrow functions instead.