### PR TITLE
Fix links to $field->yaml() and $field->toStructure()

### DIFF
--- a/content/1_docs/3_reference/3_panel/3_fields/0_structure/cheatsheet-article.txt
+++ b/content/1_docs/3_reference/3_panel/3_fields/0_structure/cheatsheet-article.txt
@@ -118,7 +118,7 @@ fields:
 
 ## Accessing structure fields in your templates
 
-To access a structure field in your templates, you can use the [`$field->yaml()`](../field-methods/yaml) and [`$field->toStructure()`](../field-methods/to-structure) methods.
+To access a structure field in your templates, you can use the [`$field->yaml()`](../../templates/field-methods/yaml) and [`$field->toStructure()`](../../templates/field-methods/to-structure) methods.
 
 ## Preview of fields in the table
 


### PR DESCRIPTION
These are under docs/reference/templates/field-methods, not docs/reference/panel/field-methods. I _think_ I got the folder tree links right, because they need to go back down two levels? You should double-check me, though!