### PR TITLE
Correctly offset GitHub source line for Kirbytext

### DIFF
--- a/site/plugins/site/src/Models/KirbyTagPage.php
+++ b/site/plugins/site/src/Models/KirbyTagPage.php
@@ -39,7 +39,15 @@ class KirbyTagPage extends HelperPage
     public function line()
     {
         if ($reflection = $this->reflection()) {
-            return $reflection->getStartLine();
+            $line = $reflection->getStartLine();
+            $line -= 2;
+
+            $attributes = $this->attributes();
+            if (count($attributes) > 0) {
+                $line -= count($attributes) + 1;
+            }
+
+            return $line;
         }
 
         return null;


### PR DESCRIPTION
`$reflection->getStartLine()` will always get us the line of the callback function, not the line where the tag definition starts. For that we have to jump two lines up, one more in case there are attributes plus an additional line per attribute.