### PR TITLE
filterBy for date

### DIFF
--- a/content/1_docs/3_reference/4_objects/0_pages/0_filter-by/method.txt
+++ b/content/1_docs/3_reference/4_objects/0_pages/0_filter-by/method.txt
@@ -7,10 +7,14 @@ Text:
 $items = $page->children()->filterBy('draft', 'yes');
 
 // fetch children with a date in the past
-$items = $page->children()->filterBy('date', '<', time());
+$items = $page->children()->filterBy(function ($child) {
+  return $child->date()->toDate() < time();
+});
 
 // fetch children with a date in the future
-$items = $page->children()->filterBy('date', '>', time());
+$items = $page->children()->filterBy(function ($child) {
+  return $child->date()->toDate() > time();
+});
 
 // fetch any page with a project template
 $items = $site->index()->filterBy('template', 'project');


### PR DESCRIPTION
Date field doesn’t return a Unix timestamp anymore. Update docs to reflect how to filter by date.