### PR TITLE
fix email template paths

### DIFF
--- a/content/1_docs/2_cookbook/0_forms/0_basic-contact-form/recipe.txt
+++ b/content/1_docs/2_cookbook/0_forms/0_basic-contact-form/recipe.txt
@@ -184,7 +184,7 @@ Here are the two email templates:
 
 The plain text template gets the extension `.php`.
 
-```php "/site/templates/email.php"
+```php "/site/templates/emails/email.php"
 Hello Company,
 
 <?= $text ?>
@@ -196,7 +196,7 @@ Hello Company,
 
 The HTML template gets the extension `html.php`.
 
-```php "/site/templates/email.html.php"
+```php "/site/templates/emails/email.html.php"
 Hello Company,
 
 <p><?= $text ?></p>


### PR DESCRIPTION
I always got a "template not found" error and wondered why, until I found out, that email templates live in a template subfolder called `emails`... This should be corrected here to prevent confusion.