### PR TITLE
Correct grammar in Escape class docs

### DIFF
--- a/content/1_docs/3_reference/9_tools/0_escape/class.txt
+++ b/content/1_docs/3_reference/9_tools/0_escape/class.txt
@@ -4,7 +4,7 @@ Class: Kirby\Toolkit\Escape
 
 Text:
 
-The Escape class is a wrapper for the (link: https://github.com/zendframework/zend-escaper text: Zend Escaper).
+The Escape class is a wrapper for (link: https://github.com/zendframework/zend-escaper text: Zend Escaper).
 
 <warning>
 The methods of this class should not be used for complex attributes like href, src, style, or any of the event handlers like onmouseover. Use `esc($string, 'js')` for event handler attributes, `esc($string, 'url')` for src attributes and `esc($string, 'css')` for style attributes.


### PR DESCRIPTION
The use of “the” with “Zend Escaper” isn’t grammatically correct.