### PR TITLE
Fix references to Toolkit classes in docs

### DIFF
--- a/content/1_docs/1_guide/17_database/guide.txt
+++ b/content/1_docs/1_guide/17_database/guide.txt
@@ -58,7 +58,7 @@ Assuming your database contains a table called `users`, you can now start queryi
 ### Example
 
 ```php
-$users = db::select('users');
+$users = Db::select('users');
 
 foreach ($users as $user) {
   echo $user->username();
@@ -68,7 +68,7 @@ foreach ($users as $user) {
 ## Select columns
 
 ```php
-$users = db::select('users', ['id', 'username']);
+$users = Db::select('users', ['id', 'username']);
 
 foreach ($users as $user) {
   echo $user->id() . ': ' . $user->username();
@@ -78,7 +78,7 @@ foreach ($users as $user) {
 ### Order rows
 
 ```php
-$users = db::select('users', '*', null, 'username DESC' );
+$users = Db::select('users', '*', null, 'username DESC' );
 
 foreach ($users as $user) {
   echo $user->id() . ': ' . $user->username();
@@ -89,7 +89,7 @@ foreach ($users as $user) {
 ### Offsets and limits
 
 ```php
-$users = db::select('users', '*', null, 'username DESC', 2, 2 );
+$users = Db::select('users', '*', null, 'username DESC', 2, 2 );
 
 foreach ($users as $user) {
   echo $user->username();
@@ -100,7 +100,7 @@ foreach ($users as $user) {
 
 
 ```php
-$users = db::select('users', '*', 'username like "%m%"');
+$users = Db::select('users', '*', 'username like "%m%"');
 
 foreach ($users as $user) {
   echo $user->username();
@@ -125,7 +125,7 @@ The `first` shortcut works similar to the `select` method above, but only select
 ### Example
 
 ```php
-$user = db::first('users');
+$user = Db::first('users');
 
 echo $user->username();
 ```
@@ -148,7 +148,7 @@ The `column` shortcut returns values from a single column.
 ### Example
 
 ```php
-$ids = db::column('users', 'id');
+$ids = Db::column('users', 'id');
 var_dump($users);
 foreach ($ids as $id) {
   echo $id;
@@ -167,7 +167,7 @@ foreach ($ids as $id) {
 ### Example
 
 ```php
-$id = db::insert('users', [
+$id = Db::insert('users', [
   'username' => 'moe',
   'email'    => 'moe@szyslak.com'
 ]);
@@ -190,7 +190,7 @@ If successful, the method returns the last `id`, otherwise `false`.
 ### Example
 
 ```php
-$bool = db::update('users', ['username' => 'zoe'], ['username' => 'moe']);
+$bool = Db::update('users', ['username' => 'zoe'], ['username' => 'moe']);
 dump($bool);
 ```
 
@@ -206,7 +206,7 @@ dump($bool);
 ### Example
 
 ```php
-$bool = db::delete('users', ['username' => 'zoe']);
+$bool = Db::delete('users', ['username' => 'zoe']);
 dump($bool);
 ```
 
@@ -222,10 +222,10 @@ dump($bool);
 ### Example
 
 ```php
-$count = db::count('users', 'id > 3');
+$count = Db::count('users', 'id > 3');
 dump($count);
 
-$count = db::count('users', 'username LIKE "%m%"');
+$count = Db::count('users', 'username LIKE "%m%"');
 dump($count);
 ```
 
@@ -243,7 +243,7 @@ dump($count);
 ### Example
 
 ```php
-$min = db::min('users', 'id');
+$min = Db::min('users', 'id');
 dump($min);
 
 ```
@@ -261,7 +261,7 @@ dump($min);
 ### Example
 
 ```php
-$max = db::max('users', 'id');
+$max = Db::max('users', 'id');
 dump($max);
 ```
 
@@ -280,7 +280,7 @@ dump($max);
 ### Example
 
 ```php
-$avg = db::avg('users', 'id');
+$avg = Db::avg('users', 'id');
 dump($avg);
 ```
 

--- a/content/1_docs/2_cookbook/2_content/0_pages-from-database/recipe.txt
+++ b/content/1_docs/2_cookbook/2_content/0_pages-from-database/recipe.txt
@@ -48,7 +48,7 @@ Here we connect to a local database, your real database should - of course - use
 Assuming that your database contains a table called comments, you can now query the database table in your templates like this:
 
 ```php "/site/templates/comments.php"
-$comments = db::select('comments');
+$comments = Db::select('comments');
 ```
 
 ## Convert to child pages
@@ -64,7 +64,7 @@ class CommentsPage extends Kirby\Cms\Page
     {
         $comments = [];
 
-        foreach (db::select('comments') as $comment) {
+        foreach (Db::select('comments') as $comment) {
             $comments[] = [
                 'slug'     => $comment->slug(),
                 'num'      => 0,
@@ -154,18 +154,18 @@ class CommentPage extends Kirby\Cms\Page
     {
         unset($data['title']);
 
-        if ($comment = db::first('comments', '*', ['slug' => $this->slug()])) {
-            return db::update('comments', $data, ['slug' => $this->slug()]);
+        if ($comment = Db::first('comments', '*', ['slug' => $this->slug()])) {
+            return Db::update('comments', $data, ['slug' => $this->slug()]);
         } else {
             $data['slug'] = $this->slug();
-            return db::insert('comments', $data);
+            return Db::insert('comments', $data);
         }
 
     }
 
     public function delete(bool $force = false): bool
     {
-        return db::delete('comments', ['slug' => $this->slug()]);
+        return Db::delete('comments', ['slug' => $this->slug()]);
     }
 
     public function title(): Kirby\Cms\Field

--- a/content/1_docs/2_cookbook/5_i18n/0_language-variables/recipe.txt
+++ b/content/1_docs/2_cookbook/5_i18n/0_language-variables/recipe.txt
@@ -42,7 +42,7 @@ return [
   'direction' => 'ltr',
   'locale' => 'de_DE',
   'name' => 'Deutsch',
-  'translations' => yaml::decode(F::read(kirby()->root('languages').'/vars/de.yml'))
+  'translations' => Yaml::decode(F::read(kirby()->root('languages').'/vars/de.yml'))
 ];
 ```
 

--- a/content/1_docs/2_cookbook/9_setup/0_migrate-site/recipe.txt
+++ b/content/1_docs/2_cookbook/9_setup/0_migrate-site/recipe.txt
@@ -137,7 +137,7 @@ In your `config.php`:
     if(!empty($builder)) {
 
       foreach($builder as $build) {
-        $missing = a::missing($build, array('title', 'template', 'uid'));
+        $missing = A::missing($build, array('title', 'template', 'uid'));
         if(!empty($missing)) continue;
           try {
             $subPage = $page->createChild([
@@ -186,7 +186,7 @@ The Kirby 2 Dashboards no longer exists in Kirby 3. With the Dashboard, Panel wi
 
 ### Syntax changes
 
-In addition to the `c::set()` settings, the standard way of adding options is now to use a `return` statement that returns an array of options:
+In addition to `Config::set()`, the standard way of adding options is now to use a `return` statement that returns an array of options:
 
 ```php "/site/config/config.php"
 <?php
@@ -315,7 +315,7 @@ $kirby->page('some/page')->delete();
 ### Various method changes
 
 - `$pagination->items()` was removed, use `$pagination->total()` or `$pagination->pages()`
-- `tpl::load()` doesn't accept a third argument anymore
+- `Tpl::load()` doesn't accept a third argument anymore
 - the `excerpt()` helper method has been removed and the parameters for the `$field->excerpt()` method have changed
 - `$page->tinyurl()` was removed
 

--- a/content/1_docs/3_reference/2_templates/0_helpers/_email/helper.txt
+++ b/content/1_docs/3_reference/2_templates/0_helpers/_email/helper.txt
@@ -45,10 +45,10 @@ if($email->send()) {
 You can set default email options in your config.php
 
 ```
-c::set('email.service', 'mail');
-c::set('email.from', 'Bastian Allgeier <bastian@getkirby.com>');
-c::set('email.replyTo', 'Bastian Allgeier <bastian@getkirby.com>');
-c::set('email.subject', 'Kirby Support');
+Config::set('email.service', 'mail');
+Config::set('email.from', 'Bastian Allgeier <bastian@getkirby.com>');
+Config::set('email.replyTo', 'Bastian Allgeier <bastian@getkirby.com>');
+Config::set('email.subject', 'Kirby Support');
 ```
 
 You can then send emails in your templates, controllers, snippets etc. with those default settings:

--- a/content/1_docs/3_reference/4_objects/0_page/0_update/method.txt
+++ b/content/1_docs/3_reference/4_objects/0_page/0_update/method.txt
@@ -30,7 +30,7 @@ try {
 ```php
 $page->update([
   'title' => function($title) {
-    return str::lower($title);
+    return Str::lower($title);
   }
 ]);
 ```

--- a/content/1_docs/3_reference/6_system/4_validators/0_size/validator.txt
+++ b/content/1_docs/3_reference/6_system/4_validators/0_size/validator.txt
@@ -3,7 +3,7 @@ Text:
 ## In your code
 
 ```php
-if(V::size(f::size('/my/file.jpg'), 12121912)) {
+if(V::size(F::size('/my/file.jpg'), 12121912)) {
   echo 'Yay, valid!';
 }
 

--- a/content/1_docs/3_reference/7_plugins/1_extensions/0_validators/extension.txt
+++ b/content/1_docs/3_reference/7_plugins/1_extensions/0_validators/extension.txt
@@ -9,7 +9,7 @@ Validators are registered with the `validators` extension. The validators extens
 Kirby::plugin('your/plugin', [
   'validators' => [
     'isGreen' => function ($value) {
-      return v::in($value, ['green','lightgreen', 'darkgreen', 'mediumgreen'];
+      return V::in($value, ['green','lightgreen', 'darkgreen', 'mediumgreen'];
     }
   ]
 ]);
@@ -19,7 +19,7 @@ In your templates, you can now check if the value is in the given array of green
 
 ```php "/site/templates/default.php"
 $input = 'lightgreen';
-if(v::isGreen($input)) {
+if(V::isGreen($input)) {
   echo 'Yay, valid!';
 } else {
   echo 'Oh no, not valid';


### PR DESCRIPTION
This should cover all the remaining class names that hadn't been changed.