### PR TITLE
Fix $page->inventory() code example

### DIFF
--- a/content/1_docs/3_reference/4_objects/0_page/0_inventory/method.txt
+++ b/content/1_docs/3_reference/4_objects/0_page/0_inventory/method.txt
@@ -6,6 +6,6 @@ The inventory array contains a list of all inventory items of the page, like the
 
 ```php
 <?php
-a::show($page->inventory());
+print_r($page->inventory());
 ?>
 ```

--- a/content/1_docs/3_reference/4_objects/0_page/0_inventory/method.txt
+++ b/content/1_docs/3_reference/4_objects/0_page/0_inventory/method.txt
@@ -6,6 +6,6 @@ The inventory array contains a list of all inventory items of the page, like the
 
 ```php
 <?php
-print_r($page->inventory());
+dump($page->inventory());
 ?>
 ```


### PR DESCRIPTION
The `a::show()` method was removed in Kirby 3, `print_r` does the same kind of thing.