### PR TITLE
Language Switch: add hreflang attribute

### DIFF
--- a/content/1_docs/1_guide/7_languages/5_switching-languages/guide.txt
+++ b/content/1_docs/1_guide/7_languages/5_switching-languages/guide.txt
@@ -23,7 +23,7 @@ The first option is to redirect users to the home page when they select another 
   <ul>
     <?php foreach($kirby->languages() as $language): ?>
     <li<?php e($kirby->language() == $language, ' class="active"') ?>>
-      <a href="<?php echo $language->url() ?>">
+      <a href="<?php echo $language->url() ?>" hreflang="<?php echo $language->code() ?>">
         <?php echo html($language->name()) ?>
       </a>
     </li>
@@ -41,7 +41,7 @@ The second option is to redirect users to the same page in the selected language
   <ul>
     <?php foreach($kirby->languages() as $language): ?>
     <li<?php e($kirby->language() == $language, ' class="active"') ?>>
-      <a href="<?= $page->url($language->code()) ?>">
+      <a href="<?= $page->url($language->code()) ?>" hreflang="<?php echo $language->code() ?>">
         <?= html($language->name()) ?>
       </a>
     </li>


### PR DESCRIPTION
`hreflang` indicates the language the linked page is in: https://support.google.com/webmasters/answer/189077?hl=en

There are a lot of ways to indicate the target page's language. I find this the simplest one. I think its a good idea to add it to the examples. If you don't feel the same feel free to close this pull request.

I left it out in the third case because that one is a bit more complicated – the language of the eventually linked page is ambiguous.