### PR TITLE
Remove trailing 's' in Files field docs

### DIFF
--- a/content/1_docs/3_reference/3_panel/3_fields/0_files/cheatsheet-article.txt
+++ b/content/1_docs/3_reference/3_panel/3_fields/0_files/cheatsheet-article.txt
@@ -120,7 +120,7 @@ gallery:
   type: files
   uploads: 
     parent: site
-    templates: files-upload
+    template: files-upload
 ```
 
 If you want to upload to the current page and only assign a template, you can directly assign it to the `uploads` property:


### PR DESCRIPTION
Correct option is `template` without the s