### PR TITLE
Fix props param type for translate

### DIFF
--- a/content/1_docs/3_reference/7_plugins/1_extensions/0_fields/extension.txt
+++ b/content/1_docs/3_reference/7_plugins/1_extensions/0_fields/extension.txt
@@ -105,7 +105,7 @@ hello: {
 
 ```php
 'props' => [
-    'message' => function (string $message) {
+    'message' => function ($message = null) {
         return I18n::translate($message);
     }
 ]
@@ -342,4 +342,3 @@ panel.plugin("your/plugin", {
   }
 });
 ```
-

--- a/content/1_docs/3_reference/7_plugins/1_extensions/0_sections/extension.txt
+++ b/content/1_docs/3_reference/7_plugins/1_extensions/0_sections/extension.txt
@@ -122,7 +122,7 @@ modified: {
 
 ```php
 'props' => [
-    'headline' => function (string $headline) {
+    'headline' => function ($headline = null) {
         return I18n::translate($headline);
     }
 ]


### PR DESCRIPTION
string type doesnt work with array param for translate like following:

```
modified:
  type: modified
  headline:
    en: Last updates
    tr: Son Güncellemeler
```