### PR TITLE
semicolon typo

### DIFF
--- a/content/1_docs/1_guide/6_blueprints/4_query-language/guide.txt
+++ b/content/1_docs/1_guide/6_blueprints/4_query-language/guide.txt
@@ -139,7 +139,7 @@ You can use array syntax and nested queries in Kirby's query syntax.
 
 ```yaml
 # arrays
-query: site.index.filterBy("template", "in", ["note", "album"]);
+query: site.index.filterBy("template", "in", ["note", "album"])
 
 # nested queries
 query: kirby.collection("some-collection").not(kirby.collection("excluded-collection"))


### PR DESCRIPTION
unnecessary semicolon, would create an error in the panel