### PR TITLE
Add sortBy blueprint examples to Pages field and Sorting Cookbook

### DIFF
--- a/content/1_docs/2_cookbook/2_content/0_sorting/recipe.txt
+++ b/content/1_docs/2_cookbook/2_content/0_sorting/recipe.txt
@@ -230,3 +230,19 @@ $usera = $kirby->users()->sortBy('language', 'desc');
 ```
 
 For files and users (and all the other stuff we can sort) we could also go to extremes, but let's keep it dry and finish here.
+
+## Sorting Panel fields
+
+In blueprints, many Panel fields can also use sortBy with a slight variation on the standard syntax. Add `sortBy:` as a field option, and then list arguments in order without quotes or commas.
+
+For example, this would display a page's children in reverse publishing order: 
+
+```yaml
+fields:
+  posts:
+    label: Blog Posts
+    type: pages
+    sortBy: num desc
+```
+
+You can see more examples of how to use sortBy in the (link: docs/reference/panel/fields/pages text: Pages field).

--- a/content/1_docs/3_reference/3_panel/3_fields/0_pages/cheatsheet-article.txt
+++ b/content/1_docs/3_reference/3_panel/3_fields/0_pages/cheatsheet-article.txt
@@ -56,6 +56,42 @@ fields:
     max: 3
 ```
 
+## Sort order
+
+By default, the Pages field displays children in ascending publishing order from oldest to newest (`num asc`). In this state, each page has a drag handle to its left, allowing users to re-order pages by clicking and dragging.
+
+If you want to use a custom sort order when viewing in the panel (for example, to list blog posts in reverse post order, or by a 'date' field or any other page field), you can use the (link: docs/reference/objects/pages/sort-by text: sortBy) option. When used as a field option, function arguments should be listed in order, without quotes or commas. Please note this disables drag handles and drag-and-drop reordering in the Panel. You can still change the post order by clicking Change status and selecting a new position.
+
+Please also note this has no effect on Kirby's internal page order, nor in the way they will be displayed in templates. To learn more about using sortBy in templates, please consult the (link: docs/cookbook/content/sorting text: Sorting) Cookbook entry.
+
+### Sort by reverse publishing order
+
+If you want to show pages from most to least recently-published, set sortBy to `num desc`. This means to sort by "number" (the number prepended to published page folders) in "descending" order (default is 'num asc' which means "by number in ascending order").
+
+```yaml
+fields:
+  posts:
+    label: Posts
+    type: pages
+    sortBy: num desc
+```
+
+### Sort alphanumerically by title
+
+You could view all pages by their `title` field sorted alphanumerically with `sortBy: title asc`.
+
+```yaml
+sortBy: title asc
+```
+
+### Sort by date and time
+
+If your pages have date and/or time fields, you can sort by those instead. As in the (link: docs/reference/objects/pages/sort-by text: sortBy template function), you can sort by more than one field by passing fields and options in order. The following would sort first by date descending and then by time descending, showing all pages in reverse chronological order according to page metadata.
+
+```yaml
+sortBy: date desc time desc
+```
+
 ## Preview images
 
 The default (preview) image is the first image in the folder. You can configure the (preview) image for each item using the `image` option:


### PR DESCRIPTION
Hi! I spent a couple of hours searching the docs and forum before figuring out how to use sortBy as a blueprint option. Specifically, I wanted to sort a `type: pages` field in reverse publishing order according to the folder number, and ultimately it took stumbling on a forum post from earlier this year to find any reference to `num` as a sortBy option.

Since it seemed like a common enough case, I've added examples to two pages. In `docs/reference/panel/fields/pages` I've added several examples of how to use sortBy as an option, including caveats about how this disables sort handles/drag-and-drop reordering and that it doesn't affect actual sort order or template output (with a link to the Sorting cookbook entry on how to do that).

Then, in `docs/cookbook/content/sorting`, I've added a subhead to the end explaining that many panel fields can use sortBy: with modified syntax, one example, and a link to the Pages field entry to learn more.

I recognize this is a somewhat tricky thing to explain, so my caveats may not fit the style guide. Please let me know if I need to change anything.

I think it might also be good to add sortBy as a Field property on the Pages field, but I'm not comfortable doing that myself.