### PR TITLE
fix: remove margin-bottom on code blocks

### DIFF
--- a/src/scss/components/code.scss
+++ b/src/scss/components/code.scss
@@ -43,7 +43,6 @@ h6 code,
   font-size: $font-size-code;
   letter-spacing: 0;
   line-height: ($line-height-code / $font-size-code);
-  margin-bottom: 1.5rem;
 
   ::selection {
     background: rgba($color-kirby-blue, .4);


### PR DESCRIPTION
There is a unnecessary `margin-bottom` on code blocks. Since they have a black background-color, the margin shows as as a black bar below the scroll bar, which looks broken.

This is also redundant because there is already a `margin-bottom: 1.5rem` from the `.text figure` selector in `text.scss`.

<img width="782" alt="Screenshot 2019-10-01 23 49 54" src="https://user-images.githubusercontent.com/4677417/66003572-c9089e00-e4a6-11e9-9e13-216fd8021589.png">
