### PR TITLE
English grammar fix

### DIFF
--- a/content/1_docs/2_cookbook/2_content/0_sitemap/recipe.txt
+++ b/content/1_docs/2_cookbook/2_content/0_sitemap/recipe.txt
@@ -37,7 +37,7 @@ Create a new snippet with the following content in `/site/snippets`:
 </urlset>
 ```
 
-## Create a new routes
+## Create new routes
 
 In your `config.php`, create these two new (glossary: route text: routes):
 


### PR DESCRIPTION
Removed "a" in front of plural route(s).