### PR TITLE
Add note for those who use Composer to download a new copy of Kirby

### DIFF
--- a/content/1_docs/2_cookbook/9_setup/0_migrate-site/recipe.txt
+++ b/content/1_docs/2_cookbook/9_setup/0_migrate-site/recipe.txt
@@ -36,6 +36,7 @@ The Kirby CLI is no longer compatible with Kirby 3. Kirby and extensions can ins
 1. Replace the old `/kirby` folder with the new `/kirby`folder.
 2. The old `index.php` is no longer compatible. Replace it with the new one.
 3. If you are on an Apache server, replace the old `.htaccess` file with the new one. On other servers, change your server configuration accordingly.
+4. If you downloaded a new copy via Composer, you will need to bring over the `/vendor` folder as well.
 
 ### Delete the `thumbs` folder
 


### PR DESCRIPTION
I use composer for new projects and wanted to also use it to download a fresh copy of Kirby 3 to update an old site. I used Composer to download in a directory next to the existing site, then followed steps 1, 2, and 3 in "Replacing core files and folders." The one important step I missed was bringing over the `/vendor` folder, which made it all work again.