### PR TITLE
Use absolute path for autoloader in custom setup

### DIFF
--- a/content/1_docs/1_guide/11_configuration/guide.txt
+++ b/content/1_docs/1_guide/11_configuration/guide.txt
@@ -153,7 +153,7 @@ The key to this setup is the `index.php` in the `public` folder:
 ```php "/public/index.php"
 <?php
 
-include '../vendor/autoload.php';
+include __DIR__ '/../vendor/autoload.php';
 
 $kirby = new Kirby([
     'roots' => [

--- a/content/1_docs/1_guide/11_configuration/guide.txt
+++ b/content/1_docs/1_guide/11_configuration/guide.txt
@@ -153,7 +153,7 @@ The key to this setup is the `index.php` in the `public` folder:
 ```php "/public/index.php"
 <?php
 
-include __DIR__ '/../vendor/autoload.php';
+include __DIR__ . '/../vendor/autoload.php';
 
 $kirby = new Kirby([
     'roots' => [


### PR DESCRIPTION
After setting up Kirby in a modern environment (`public` dir, …) and creating a custom PHP router, calling the `public/index.php` results in `autoloader.php not found`, because it's called from a relative path.

In the [Shared storage folder](https://getkirby.com/docs/guide/configuration#custom-url-setup) example below the [Public folder setup](https://getkirby.com/docs/guide/configuration#custom-folder-setup__public-folder-setup), the autoloader is also called via an absolute path.