### PR TITLE
Document class aliases #580

### DIFF
--- a/content/1_docs/1_guide/5_templates/3_php-api/guide.txt
+++ b/content/1_docs/1_guide/5_templates/3_php-api/guide.txt
@@ -8,14 +8,22 @@ Intro: Kirby has a mighty PHP API, which you can use in your snippets, templates
 
 Text:
 
-## Objects
+## Key objects
 
-| Object | Description |
+| Object available | Description |
 |-|-|
 | (link: docs/reference/objects/kirby text: `$kirby` ›) | The `$kirby` class is the heart and soul of Kirby. It's the access point for registered users, the current request, route, plugins and more. |
 | (link: docs/reference/objects/site text: `$site` ›) | The `$site` object represents the root of your site with all the information stored in `/content/site.txt`. |
 | (link: docs/reference/objects/pages text: `$pages` ›) | The `$pages` object contains the first level of pages. It can be used to build the main menu or dive deeper into the structure of your site. |
 | (link: docs/reference/objects/page text: `$page` ›) | The `$page` object represents the currently active page. It gives you access to the page's data, attached files, subpages and more. |
+
+## All the classes
+
+There are a lot more classes and objects at play within Kirby. You can find the most common ones in the Reference:
+
+- (link: docs/reference/objects text: Most important objects)
+- (link: docs/reference/@ text: Advanced: all classes)
+- (link: docs/reference/@/aliases text: Class aliases)
 
 
 ## Permissions

--- a/content/1_docs/3_reference/10_@/1_classes/packages.txt
+++ b/content/1_docs/3_reference/10_@/1_classes/packages.txt
@@ -1,4 +1,4 @@
-Title: Advanced
+Title: All classes
 ----
 Packages:
 - Api

--- a/content/1_docs/3_reference/10_@/2_aliases/cheatsheet-section.txt
+++ b/content/1_docs/3_reference/10_@/2_aliases/cheatsheet-section.txt
@@ -1,0 +1,13 @@
+Title: Aliases
+
+----
+
+Excerpt: In Kirby, classes are separated in different namespaces such as `Kirby\Cms\` or `Kirby\Http\`. Aliases help to access specific classes without the need to mention their namespace.
+
+----
+
+Text:
+
+## Available aliases
+
+(docs: class-aliases)

--- a/content/1_docs/3_reference/10_@/link.txt
+++ b/content/1_docs/3_reference/10_@/link.txt
@@ -1,0 +1,3 @@
+Title: Advanced
+----
+Link: docs/reference/@/classes

--- a/content/1_docs/3_reference/9_tools/0_config/class.txt
+++ b/content/1_docs/3_reference/9_tools/0_config/class.txt
@@ -1,1 +1,0 @@
-Class: Kirby\Toolkit\Config

--- a/site/plugins/site/src/Models/ClassPage.php
+++ b/site/plugins/site/src/Models/ClassPage.php
@@ -17,6 +17,13 @@ class ClassPage extends Page
     protected $docBlock;
     protected $reflection;
 
+    public function alias()
+    {
+        $aliases = require $this->kirby()->root('kirby') . '/config/aliases.php';
+        $alias   = array_search($this->className(), $aliases);
+        return new Field($this, 'alias', $alias !== false ? $alias : null);
+    }
+
     public function children()
     {
 
@@ -45,7 +52,6 @@ class ClassPage extends Page
             if ($slug === '__construct') {
                 $num = 0;
             }
-
 
             if ($page = $pages->find($slug)) {
                 $content = $page->content()->toArray();

--- a/site/plugins/site/src/Models/MethodPage.php
+++ b/site/plugins/site/src/Models/MethodPage.php
@@ -10,6 +10,15 @@ use ReflectionMethod;
 class MethodPage extends HelperPage
 {
 
+    public function alias()
+    {
+        if ($this->methodName() === '__construct') {
+            return $this->parent()->alias();
+        }
+
+        return new Field($this, 'alias', null);
+    }
+
     public function className(): string
     {
         return $this->parent()->className();

--- a/site/plugins/site/src/Models/PackagesPage.php
+++ b/site/plugins/site/src/Models/PackagesPage.php
@@ -16,7 +16,7 @@ class PackagesPage extends Page
             return $this->children;
         }
 
-        $pages = [];
+        $pages = parent::children()->toArray();
 
         foreach ($this->packages()->yaml() as $package) {
 

--- a/site/snippets/cheatsheet.article.meta.php
+++ b/site/snippets/cheatsheet.article.meta.php
@@ -1,9 +1,35 @@
+<?php
+use Kirby\Site\Models\ClassPage;
+use Kirby\Site\Models\MethodPage;
+?>
+
 <ul class="cheatsheet-article-meta">
+
   <?php if ($page->since()->isNotEmpty()): ?>
   <li>
     Since <code><?= version($page->since(), '%s') ?></code>
   </li>
   <?php endif ?>
+
+  <?php if (is_a($page, ClassPage::class) === true): ?>
+  <li>
+    Full class name: <code><?= $page->className() ?></code>
+  </li>
+  <?php endif ?>
+  <?php if (
+    is_a($page, MethodPage::class) === true &&
+    $page->methodName() === '__construct'
+  ): ?>
+  <li>
+    Full class name: <code><?= $page->parent()->className() ?></code>
+  </li>
+  <?php endif ?>
+  <?php if ($page->alias()->isNotEmpty()): ?>
+  <li>
+    Alias: <code><?= ucfirst($page->alias()) ?></code>
+  </li>
+  <?php endif ?>
+
   <?php if ($page->auth()->isNotEmpty()): ?>
   <li>
     <?php icon('lock') ?> <code data-tooltip="<a href='<?= url('docs/guide/users/permissions') ?>'><strong>Permission <code><?= $page->auth() ?></code></strong><br>is required. Learn more ›</a>">
@@ -11,6 +37,7 @@
     </code>
   </li>
   <?php endif ?>
+
   <?php if ($page->guide()->isNotEmpty()): ?>
   <li>
     <a href="<?= url('docs/guide/' . $page->guide()) ?>">
@@ -18,4 +45,5 @@
     </a>
   </li>
   <?php endif ?>
+
 </ul>

--- a/site/snippets/docs/class-aliases.php
+++ b/site/snippets/docs/class-aliases.php
@@ -1,0 +1,8 @@
+| Alias | Full class |
+|--|--|
+<?php
+$aliases = require $kirby->root('kirby') . '/config/aliases.php';
+foreach ($aliases as $alias => $class) :
+?>
+|`<?= ucfirst($alias) ?>`|`<?= $class ?>`|
+<?php endforeach ?>


### PR DESCRIPTION
#### Adds section to Kirby's PHP API guide:
<img width="627" alt="Screen Shot 2019-11-03 at 17 56 50" src="https://user-images.githubusercontent.com/3788865/68088866-6fa7dc00-fe63-11e9-84d0-f340c7a967b6.png">

#### Adds new "Aliases" item to `Advanced` reference - and a dedicated one for "all classes":
<img width="403" alt="Screen Shot 2019-11-03 at 17 53 02" src="https://user-images.githubusercontent.com/3788865/68088871-759dbd00-fe63-11e9-942a-c4af7ef864fc.png">

#### Adds aliases reference:
<img width="1008" alt="Screen Shot 2019-11-03 at 17 53 13" src="https://user-images.githubusercontent.com/3788865/68088878-8fd79b00-fe63-11e9-8607-567edb38c388.png">

#### Adds "Full class name" and "Alias" (if available) meta to class pages as well as __construct method pages:
<img width="1004" alt="Screen Shot 2019-11-03 at 17 52 54" src="https://user-images.githubusercontent.com/3788865/68088882-99f99980-fe63-11e9-8da1-7c0ae2129d6c.png">

