### PR TITLE
Missing attribute name in <since> tag

### DIFF
--- a/content/1_docs/3_reference/3_panel/3_fields/0_structure/cheatsheet-article.txt
+++ b/content/1_docs/3_reference/3_panel/3_fields/0_structure/cheatsheet-article.txt
@@ -150,7 +150,7 @@ fields:
 
 ### Hide toggle field text in preview
 
-<since="3.3.0">
+<since v="3.3.0">
 When using toggle fields within structures, displaying the field's text in the preview can sometimes look cluttered. You can hide the text with the `text` option in the columns' definition.
 
 ```yaml


### PR DESCRIPTION
Goofs up the formatting of the 'toggle' section of the structure field docs.