### PR TITLE
Typo in code snippet 'homer' instead of 'home'

### DIFF
--- a/content/1_docs/2_cookbook/3_templating/0_one-pager/recipe.txt
+++ b/content/1_docs/2_cookbook/3_templating/0_one-pager/recipe.txt
@@ -43,7 +43,7 @@ In this tutorial we are going to build a very basic one-pager. Here’s a rough 
   contact.txt
 error/
   error.txt
-homer/
+home/
   home.txt
 ```
 


### PR DESCRIPTION
In one of the code snippets, the folder is shown as 'homer'. It should be 'home'.