### PR TITLE
Syntax note

### DIFF
--- a/content/1_docs/3_reference/7_plugins/1_extensions/0_blueprints/extension.txt
+++ b/content/1_docs/3_reference/7_plugins/1_extensions/0_blueprints/extension.txt
@@ -22,6 +22,8 @@ Kirby::plugin('your/plugin', [
 ]);
 ```
 
+<info>The blueprint key must start with 'pages/...' in order to work.</info>
+
 ## Array definition
 
 Alternatively, you can also pass the blueprint definition as an array instead of a file:

--- a/content/1_docs/3_reference/7_plugins/1_extensions/0_blueprints/extension.txt
+++ b/content/1_docs/3_reference/7_plugins/1_extensions/0_blueprints/extension.txt
@@ -22,7 +22,7 @@ Kirby::plugin('your/plugin', [
 ]);
 ```
 
-<info>The blueprint key must start with 'pages/...' in order to work.</info>
+<info>The blueprint key must start with 'pages/...', 'user/...', etc. to activate in the designated locations.</info>
 
 ## Array definition
 


### PR DESCRIPTION
I didn't realize the `pages/` prefix was needed for the blueprint value. Thought a note to that effect may help someone else (and me when I come back to this topic).