### PR TITLE
Missing { after if conditional

### DIFF
--- a/content/1_docs/2_cookbook/3_templating/0_blueprints-in-frontend/recipe.txt
+++ b/content/1_docs/2_cookbook/3_templating/0_blueprints-in-frontend/recipe.txt
@@ -98,7 +98,7 @@ return [
   'hooks' => [
     'page.create:after' => function ($page) {
       $autoPublish = $page->blueprint()->options()['autoPublish'] ?? false;
-      if($autoPublish)
+      if($autoPublish) {
         $page->changeStatus('listed');
       }
     }


### PR DESCRIPTION
In one of the examples, the opening `{` is missing just after the conditional.

```
if($autoPublish) 
    $page->changeStatus('listed');
}
```

should be:

```
if($autoPublish) {
    $page->changeStatus('listed');
}
```