### PR TITLE
"categories" question

### DIFF
--- a/content/1_docs/2_cookbook/3_templating/0_fetching-field-options/recipe.txt
+++ b/content/1_docs/2_cookbook/3_templating/0_fetching-field-options/recipe.txt
@@ -187,7 +187,7 @@ fields:
 ```php
 <?php
 $field = $page->blueprint()->field('category');
-$categories = $page->categories()->split(',');
+$categories = $page->category()->split(',');
 foreach ($categories as $category) {
     echo $field['options'][$category] ?? html($category);
 }


### PR DESCRIPTION
On line 190 in the template code sample, shouldn't this:
`…->categories()->…`
be this:
`…->category()->…`
…since it's referencing a field defined as `category` (from line 176)?

If this is not true, then there is some pluralization of field names that I'm not aware of (and that's very possible). ;)