### PR TITLE
Use accessible markup in example

### DIFF
--- a/content/1_docs/3_reference/4_objects/0_site/0_breadcrumb/method.txt
+++ b/content/1_docs/3_reference/4_objects/0_site/0_breadcrumb/method.txt
@@ -3,15 +3,15 @@ Text:
 ## Example
 
 ```php
-<nav class="breadcrumb" role="navigation">
-  <ul>
+<nav class="breadcrumb" role="navigation" aria-label="breadcrumb">
+  <ol>
     <?php foreach($site->breadcrumb() as $crumb): ?>
     <li>
-      <a href="<?= $crumb->url() ?>">
+      <a href="<?= $crumb->blogurl() ?>" <?= e($crumb->isActive(), 'aria-current="page"') ?>>
         <?= html($crumb->title()) ?>
       </a>
     </li>
     <?php endforeach ?>
-  </ul>
+  </ol>
 </nav>
 ```

--- a/content/1_docs/3_reference/4_objects/0_site/0_breadcrumb/method.txt
+++ b/content/1_docs/3_reference/4_objects/0_site/0_breadcrumb/method.txt
@@ -3,7 +3,7 @@ Text:
 ## Example
 
 ```php
-<nav class="breadcrumb" role="navigation" aria-label="breadcrumb">
+<nav class="breadcrumb" aria-label="breadcrumb">
   <ol>
     <?php foreach($site->breadcrumb() as $crumb): ?>
     <li>


### PR DESCRIPTION
As per https://github.com/scottaohara/a11y_breadcrumbs this would be the preferred markup for a breadcrumb navigation.