### PR TITLE
Fix "Timeout" typo in Auth-reference

### DIFF
--- a/content/1_docs/3_reference/6_system/1_options/0_auth/cheatsheet-article.txt
+++ b/content/1_docs/3_reference/6_system/1_options/0_auth/cheatsheet-article.txt
@@ -19,7 +19,7 @@ return [
 ];
 ```
 
-## Timout
+## Timeout
 
 You can also set the timeout in seconds for the period of time against which the number of trials is counted. The default is 3600.
 


### PR DESCRIPTION
During Bastians workshop I noticed this little mistake on https://getkirby.com/docs/reference/system/options/auth#timout
![Screenshot](https://user-images.githubusercontent.com/326332/72904723-417dbe00-3d27-11ea-815e-271dd5b5591e.jpg)
