### PR TITLE
Add missing backtick to date field docs

### DIFF
--- a/content/1_docs/3_reference/3_panel/3_fields/0_date/cheatsheet-article.txt
+++ b/content/1_docs/3_reference/3_panel/3_fields/0_date/cheatsheet-article.txt
@@ -33,7 +33,7 @@ fields:
 
 ## Time settings
 
-To enable time imput, set the `time` option to `true:
+To enable time imput, set the `time` option to `true`:
 
 ```yaml
 fields:


### PR DESCRIPTION
This pull request adds a missing backtick to "`true`".