### PR TITLE
Use require instead of require_once

### DIFF
--- a/content/1_docs/2_cookbook/7_extensions/0_first-panel-section/recipe.txt
+++ b/content/1_docs/2_cookbook/7_extensions/0_first-panel-section/recipe.txt
@@ -51,7 +51,7 @@ We also need an `index.php` file that contains the Kirby plugin wrapper, in whic
 
 Kirby::plugin('getkirby/linksection', [
     'sections' => [
-        'links' => require_once __DIR__ . '/sections/links.php',
+        'links' => require __DIR__ . '/sections/links.php',
     ],
 ]);
 ```


### PR DESCRIPTION
Although the plugin file should only be loaded once, I think using `require` makes more sense at this point, because loading the file for a second time would not register the same plugin data, as on first load.