### PR TITLE
Possibly error in the example

### DIFF
--- a/content/1_docs/3_reference/2_templates/0_helpers/0_kirbytext/helper.txt
+++ b/content/1_docs/3_reference/2_templates/0_helpers/0_kirbytext/helper.txt
@@ -14,5 +14,5 @@ Text:
 ### Parse KirbyText for another page
 
 ```php
-<?= kirbytext('(\image: road.jpg)', [$page->children()->first()]) ?>
+<?= kirbytext('(\image: road.jpg)', ['parent' => $page->children()->first()]) ?>
 ```


### PR DESCRIPTION
Calling the `kirbytext()` helper from within a page method, I could only get it to render (image:) tags when passing the page object in the `$data` array; however, this only works when using an associative array:

Doesn't work (following the example on this reference page):

```php
return kirbytext($text, [$this]);
```

Works (based on the code in [Cms/App.php#L656](https://github.com/getkirby/kirby/blob/fa549aae38d5555e297b1870071418c5bb4a95f1/src/Cms/App.php#L656)):

```php
return kirbytext($text, ['parent' => $this]);
```

I'm not 100% sure is the documentation wrong or did I do something wrong, maybe someone "in the know" could check?