### PR TITLE
Fix typo in docs/reference/objects/site/search

### DIFF
--- a/content/1_docs/3_reference/4_objects/0_site/0_search/method.txt
+++ b/content/1_docs/3_reference/4_objects/0_site/0_search/method.txt
@@ -6,7 +6,7 @@ Text:
 | ---- | ---- | ---- |
 | `minlength` | 2 | Minimum length of search word
 | `fields` | `[]` | Fields to search in, defaults to all fields
-| `words` | `false` | Ssearch full words only
+| `words` | `false` | Search full words only
 | `score` | `['id' => 64,'title' => 64]` | Score per field
 | `stopwords`| `[]` | Array of words to exclude from search
 


### PR DESCRIPTION
`Ssearch` -> `Search` in `docs/reference/objects/site/search`