### PR TITLE
Fixed a typo in the toggle input documentation

### DIFF
--- a/content/1_docs/3_reference/7_plugins/4_ui/0_toggle-input/ui.txt
+++ b/content/1_docs/3_reference/7_plugins/4_ui/0_toggle-input/ui.txt
@@ -5,7 +5,7 @@ Title: Toggle Input
 Text:
 
 ```html
-<k-input v-model="toggle" name="toggle" type="Toggle" />
+<k-input v-model="toggle" name="toggle" type="toggle" />
 ```
 
 ## Props


### PR DESCRIPTION
This simple typo caused the example to not produce any results when copy and pasted into a Kirby plugin