### PR TITLE
Add missing footnotes plugin

### DIFF
--- a/content/plugins/sylvainjule/footnotes/plugin.txt
+++ b/content/plugins/sylvainjule/footnotes/plugin.txt
@@ -1,0 +1,13 @@
+Title: Footnotes
+
+----
+
+Repository: https://github.com/sylvainjule/kirby-footnotes
+
+----
+
+Category: text
+
+----
+
+Description: This plugin extends Kirby 3 with some basic, extremely easy and unopinionated footnote functionalities.


### PR DESCRIPTION
Unless omitted on purpose, this plugin by @sylvainjule is missing from the plugin directory.