### PR TITLE
Example for "Language specific URLs" out of date

### DIFF
--- a/content/1_docs/1_guide/7_languages/1_introduction/guide.txt
+++ b/content/1_docs/1_guide/7_languages/1_introduction/guide.txt
@@ -103,12 +103,17 @@ By default, the URL of your site changes and the language code is added to the U
 <?php
 
 return [
-  'code' => 'en',
-  'default' => true,
-  'direction' => 'ltr',
-  'locale' => 'en_US',
-  'name' => 'English',
-  'url' => '/',
+    'code' => 'en',
+    'default' => true,
+    'direction' => 'ltr',
+    'locale' => [
+        'LC_ALL' => 'en_GB'
+    ],
+    'name' => 'English',
+    'translations' => [
+
+    ],
+    'url' => '/'
 ];
 ```
 


### PR DESCRIPTION
The example file for "Language specific URLs" is out of date which may confuse new users to Kirby. I've replaced it with the current file contents.