### PR TITLE
Business hours example is incorrect

### DIFF
--- a/content/1_docs/2_cookbook/5_i18n/0_using-variables-in-language-strings/recipe.txt
+++ b/content/1_docs/2_cookbook/5_i18n/0_using-variables-in-language-strings/recipe.txt
@@ -69,7 +69,7 @@ echo I18n::template('file.max.error', null, [
 $from = 8;
 $to   = 20;
 
-echo I18n::template('file.max.error', null, [
+echo I18n::template('business.hours', null, [
     'from' => $from,
     'to'   => $to
 ]);


### PR DESCRIPTION
I think the original author copied and pasted the third example `echo I18n::template('file.max.error', null, [` when it should be `echo I18n::template('business.hours', null, [`.