### PR TITLE
Fix link to PHP `strftime` function in `toDate` docs

### DIFF
--- a/content/1_docs/3_reference/2_templates/0_field-methods/0_to-date/field-method.txt
+++ b/content/1_docs/3_reference/2_templates/0_field-methods/0_to-date/field-method.txt
@@ -23,4 +23,4 @@ Text:
 
 Check out PHP's date function docs for all available formatting options: https://www.php.net/manual/en/function.date.php.
 
-If you use the `strftime` date handler, the format syntax is different: https://www.php.net/manual/en/function.strtotime.
+If you use the `strftime` date handler, the format syntax is different: https://www.php.net/manual/en/function.strftime.php.


### PR DESCRIPTION
The page used to link to the PHP function `strtotime`, which takes a different format than `strftime`.