### PR TITLE
Update recipe.txt

### DIFF
--- a/content/1_docs/2_cookbook/3_templating/0_blueprints-in-frontend/recipe.txt
+++ b/content/1_docs/2_cookbook/3_templating/0_blueprints-in-frontend/recipe.txt
@@ -42,7 +42,7 @@ dump($blueprintTitle);
 With
 
 ```php
-$fields = page('photography')->blueprint()->fields();
+$fields = $page->blueprint()->fields();
 dump($fields);
 ```
 


### PR DESCRIPTION
Added a missing $.
Deleted ('photography'), which was not in line with the other examples in this cookbook and hence could confuse readers.