### PR TITLE
more consistency in controller update

### DIFF
--- a/content/1_docs/2_cookbook/9_setup/0_migrate-site/recipe.txt
+++ b/content/1_docs/2_cookbook/9_setup/0_migrate-site/recipe.txt
@@ -264,7 +264,7 @@ to
 ```php
 <?php
 
-return function ($kirby) {
+return function ($site, $pages, $page, $kirby) {
 
   $args = $kirby->route()->arguments();
     // contains all arguments from the current route


### PR DESCRIPTION
In the example, it was unclear that we still need the $site, $pages, and $page variables as arguments/parameters in a controller when we upgrade to Kirby 3. Keeping those as parameters highlights that just the $args variable was removed.