### PR TITLE
Fix redundant sortBy in cheatsheet-article.txt

### DIFF
--- a/content/1_docs/3_reference/3_panel/6_samples/0_events/cheatsheet-article.txt
+++ b/content/1_docs/3_reference/3_panel/6_samples/0_events/cheatsheet-article.txt
@@ -41,10 +41,9 @@ listed:
 type: pages
 headline: Events
 parent: site.find("events")
-sortBy: from asc
+sortBy: from desc
 template: event
 empty: No events yet
-sortBy: date desc
 ```
 
 ### Result


### PR DESCRIPTION
Remove the redundant `sortBy` property from the `sections/events.yml` example
and update the first occasion to use desc sorting, assuming it is meant to show
the most recent events first