### PR TITLE
Custom sorting requires corresponding field

### DIFF
--- a/content/1_docs/3_reference/3_panel/1_blueprints/0_page/cheatsheet-article.txt
+++ b/content/1_docs/3_reference/3_panel/1_blueprints/0_page/cheatsheet-article.txt
@@ -68,6 +68,8 @@ num: zero
 
 ### Sorting by a custom sort number field
 
+You may use a field value, for example from a field called `customSortNumberField`, to customize the sort order:
+
 ```yaml
 num: '{{ page.customSortNumberField }}'
 ```
@@ -75,6 +77,8 @@ num: '{{ page.customSortNumberField }}'
 The return value of the query has to be an integer which will be used for sorting. Learn more about Kirby's (link: docs/guide/blueprints/query-language text: query language).
 
 ### Chronological sorting by date field
+
+If your page blueprint contains a date field, you can use that date (and, optionally time) to sort your pages chronologically. For example, for a date field named `created`, you can apply the following:
 
 #### By date
 ```yaml


### PR DESCRIPTION
While absolutely obvious, this threw me off for a moment as it is not clearly stated to be an example, not working-out-the-box code ...and it's apparently [happened to others](https://forum.getkirby.com/t/sort-subpages-by-published-date-in-pages-section/13949/9) as well.

Maybe two added paragraphs like this could make the obvious explicit; highlighting that this only works with a corresponding field in the blueprint?