### PR TITLE
Editor migration: field method in templates

### DIFF
--- a/content/1_docs/3_reference/3_panel/3_fields/0_blocks/cheatsheet-article.txt
+++ b/content/1_docs/3_reference/3_panel/3_fields/0_blocks/cheatsheet-article.txt
@@ -499,6 +499,10 @@ fields:
     type: blocks
 ```
 
+### Your templates
+
+The Editor used a field method called `$page->blocks()->blocks()`. This has to be replaced with `$page->blocks()->toBlocks()`
+
 ### Changed snippets
 
 The following block types have changed in the Blocks field and you need to move and rename your snippets if you have customized them in your installation.


### PR DESCRIPTION
Feedback from my first site migration to 3.5:

The Editor used field method `->blocks()` in templates; after migrating to Blocks this is now `->toBlocks()` but that's not mentioned in the docs. Copied this paragraph from the "Builder migration" section.