### PR TITLE
Docs for 3.5.1

### DIFF
--- a/content/1_docs/1_guide/10_authentication/3_frontend-login/guide.txt
+++ b/content/1_docs/1_guide/10_authentication/3_frontend-login/guide.txt
@@ -6,7 +6,7 @@ Text:
 
 Kirby's `Auth` class provides the following methods that can be used for authentication. All methods will throw `Exception`s if the input is not valid.
 
-## Login with email and password
+## Logging in with email and password
 
 ```php
 $kirby->auth()->login(string $email, string $password, bool $long = false);
@@ -19,41 +19,37 @@ You can find an example how to use this method in our (link: docs/cookbook/secur
 ## Creating an authentication challenge
 
 ```php
-$kirby->auth()->createChallenge(string $email, bool $long = false, string $mode = 'login');
+$status = $kirby->auth()->createChallenge(string $email, bool $long = false, string $mode = 'login');
 ```
 
-By calling this method, you can create an authentication challenge (e.g. for passwordless login or password reset). Kirby will automatically choose the challenge based on the user's email address and the provided `$mode` (which can be `login` or `password-reset`) using the (link: docs/reference/system/options/auth#authentication-challenges__challenge-priority text: configured challenge priorities).
+This method can be used for passwordless login or password reset.
 
-The method returns the name of the challenge that was created (e.g. `'email'`) or `null` if no challenge was available for the user.
+It creates an authentication challenge (for example by sending an email with a login code). The type of challenge that gets created is determined automatically based on the user's email address and the provided `$mode` (which can be `login` or `password-reset`). The (link: docs/reference/system/options/auth#authentication-challenges__challenge-priority text: configured challenge priorities) are respected.
 
-<warning>
-Be careful not to leak a return value of `null` to the visitor because it could be used to tell if the user exists at all (Kirby will create and return a challenge for a valid user while it will return `null` for users that don't exist). This information could be used by attackers.
-
-Kirby (link: docs/reference/system/options/auth#authentication-challenges__challenge-priority text: "fakes" an email challenge) in this situation, which you can also do like this:
+The `$auth->createChallenge()` method returns the authentication status object. This object contains all necessary information about the next steps:
 
 ```php
-// default to a faked email challenge if `null` gets returned
-$challenge = $kirby->auth()->createChallenge(...) ?? 'email';
+$status->challenge(); // for example 'email', 'totp', ...
+$status->email();     // email address of the pending authentication
+$status->status();    // 'pending' if a challenge is active
+$status->toArray();   // all public information combined in an array
 ```
 
-The actual `null` value can be useful for special use-cases or debugging, but please don't display it to the user.
-</warning>
+<info>
+For security, the status object with a `pending` challenge is (link: docs/reference/system/options/auth#authentication-challenges__challenge-priority text: also returned if no challenge was available for the user) (e.g. if the user doesn't exist or no suitable challenge was found). This is because Kirby would otherwise leak which users exist and which don't, which is a piece of information that could be used by attackers. In `debug` mode, an `Exception` will be thrown in this case, but in production it's important to keep this information secret.
 
-You can detect if a challenge is active by checking the `kirby.challenge.email` key in the visitor's session. This key will always be set, even if `null` was returned from the method (for the same reasons explained in the warning above).
+If your code needs to know if a challenge was really created **and you know what you are doing**, you can override this security feature by calling `$status->challenge(false)`.
+</info>
 
-If an actual challenge was created, the `kirby.challenge.type` session key will contain the name of the session (e.g. `'email'`). If the `kirby.challenge.email` key is set but `kirby.challenge.type` isn't, please fake a challenge to avoid leaking whether the user exists (also like explained in the warning above).
+Kirby remembers the pending authentication status via the user's session. You can access the status at any time with `$kirby->auth()->status()`.
 
 ## 2FA login
 
 ```php
-$kirby->auth()->login2fa(string $email, string $password, bool $long = false);
+$status = $kirby->auth()->login2fa(string $email, string $password, bool $long = false);
 ```
 
-This method is a combination of the `login()` method and the `createChallenge()` method: It will first validate the password and then create an authentication challenge (which will be returned from the method like explained above). The user is only logged in after both steps are done.
-
-<warning>
-The warning from the section above also applies here.
-</warning>
+This method is a combination of the `login()` method and the `createChallenge()` method: It will first validate the password and then create an authentication challenge (which will be returned in the status object like explained above). The user is only logged in after both steps are done.
 
 ## Verifying a provided code
 

--- a/content/1_docs/1_guide/13_emails/guide.txt
+++ b/content/1_docs/1_guide/13_emails/guide.txt
@@ -218,7 +218,11 @@ return [
 ];
 ```
 
-You can also use `tls` or `ssl` explicitly via the `security` key.
+<since v="3.5.1">
+If `security` is set to `true`, Kirby automatically converts it to `'tls'` or `'ssl'` depending on the configured port. If no port is given and secure transport is enabled, the port is set to 587 (the common port for SMTP over TLS).
+</since>
+
+You can also use `'tls'` or `'ssl'` explicitly via the `security` key.
 
 ### With authentication
 

--- a/content/1_docs/3_reference/3_panel/3_fields/0_blocks/cheatsheet-article.txt
+++ b/content/1_docs/3_reference/3_panel/3_fields/0_blocks/cheatsheet-article.txt
@@ -48,7 +48,7 @@ min | `int` | - | Minimum number of required blocks
 pretty | `bool` | `false` | Saves pretty printed JSON in text files
 required | `bool` | `false` | If true, the field has to be filled in correctly to be saved.
 translate | `bool` | `true` | If false, the field will be disabled in non-default languages and cannot be translated. This is only relevant in multi-language setups.
-when |  | - | Conditions when the field will be shown (since 3.1.0)
+when |  | - | Conditions when the field will be shown (since 3.5.1)
 width | `string` | `1/1` | The width of the field in the field grid. Available widths: `1/1`, `1/2`, `1/3`, `1/4`, `2/3`, `3/4`
 
 ## Defining Fieldsets
@@ -63,7 +63,7 @@ fields:
 
 (screenshot: single.png)
 
-However, you can fully customize the selector for new block types with sorted block types and groups. 
+However, you can fully customize the selector for new block types with sorted block types and groups.
 
 To change the order of available blocks, list them manually with the `fieldsets` option:
 

--- a/content/1_docs/3_reference/3_panel/3_fields/0_layout/cheatsheet-article.txt
+++ b/content/1_docs/3_reference/3_panel/3_fields/0_layout/cheatsheet-article.txt
@@ -110,4 +110,47 @@ fields:
 
 (screenshot: layout-settings.png)
 
+## Reusing and extending layout settings
+
+If you always use the same settings in layouts and want to easily update all of them from a single file without repeating, you can reuse or extend the layout settings. Let's see how it is used together.
+
+**Sample settings fields**
+
+```yaml "/site/blueprints/fields/settings.yml"
+fields:
+  class:
+    type: text
+    width: 1/2
+  id:
+    type: text
+    width: 1/2
+  image:
+    label: Background image
+    type: files
+```
+
+**Simple reuse**
+
+```yaml
+fields:
+  layout:
+    type: layout
+    settings: fields/settings
+```
+
+**Extended reuse**
+
+```yaml
+fields:
+  layout:
+    type: layout
+    settings:
+      extends: fields/settings
+      fields:
+        color:
+          label: Background color
+          type: text
+          default: FFF
+```
+
 (docs: layouts/to-layouts)

--- a/content/1_docs/3_reference/3_panel/3_fields/0_layout/cheatsheet-article.txt
+++ b/content/1_docs/3_reference/3_panel/3_fields/0_layout/cheatsheet-article.txt
@@ -51,6 +51,25 @@ Those layouts will then show up in the layout selector when an editor creates a 
 
 (screenshot: selector.png)
 
+### Available widths
+<since v="3.5.1">
+
+The layout field supports up to 12 columns and all are listed below.
+
+- `1/1` `1/2` `1/3` `1/4` `1/6` `1/12`
+- `2/2` `2/3` `2/4` `2/6` `2/12`
+- `3/3` `3/4` `3/6` `3/12`
+- `4/4` `4/6` `4/12`
+- `5/6` `5/12`
+- `6/6` `6/12`
+- `7/12`
+- `8/12`
+- `9/12`
+- `10/12`
+- `11/12`
+- `12/12`
+</since>
+
 ## Fieldsets
 
 The layout field also accepts the `fieldsets` option from the blocks field to control blocks in columns.
@@ -110,8 +129,8 @@ fields:
 
 (screenshot: layout-settings.png)
 
-<since v="3.5.1">
 ## Reusing and extending layout settings
+<since v="3.5.1">
 
 If you always use the same options in layouts and want to easily update all of them from a single file without repeating the options, you can reuse or extend the layout settings. Let's see how:
 

--- a/content/1_docs/3_reference/3_panel/3_fields/0_layout/cheatsheet-article.txt
+++ b/content/1_docs/3_reference/3_panel/3_fields/0_layout/cheatsheet-article.txt
@@ -110,9 +110,10 @@ fields:
 
 (screenshot: layout-settings.png)
 
+<since v="3.5.1">
 ## Reusing and extending layout settings
 
-If you always use the same settings in layouts and want to easily update all of them from a single file without repeating, you can reuse or extend the layout settings. Let's see how it is used together.
+If you always use the same options in layouts and want to easily update all of them from a single file without repeating the options, you can reuse or extend the layout settings. Let's see how:
 
 **Sample settings fields**
 
@@ -152,5 +153,6 @@ fields:
           type: text
           default: FFF
 ```
+</since>
 
 (docs: layouts/to-layouts)

--- a/content/1_docs/3_reference/6_system/1_options/0_auth/cheatsheet-article.txt
+++ b/content/1_docs/3_reference/6_system/1_options/0_auth/cheatsheet-article.txt
@@ -191,5 +191,5 @@ A challenge will be skipped if it isn't available in general or for the user who
 
 The `email` challenge is always available as it doesn't need additional configuration (only in some cases the SMTP options). It is also enabled by default if no custom priorities are defined.
 
-If none of the configured challenges is available, Kirby will "fake" an email challenge to avoid leaking security-relevant information (e.g. whether the user exists). In debug mode, there will be a clear error message instead.
+If none of the configured challenges is available, Kirby will "fake" the last configured challenge to avoid leaking security-relevant information (e.g. whether the user exists). In debug mode, there will be a clear error message instead.
 </since>

--- a/content/1_docs/3_reference/6_system/1_options/0_email/cheatsheet-article.txt
+++ b/content/1_docs/3_reference/6_system/1_options/0_email/cheatsheet-article.txt
@@ -36,7 +36,11 @@ return [
 ];
 ```
 
-You can also use `tls` or `ssl` explicitly via the `security` key:
+<since v="3.5.1">
+If `security` is set to `true`, Kirby automatically converts it to `'tls'` or `'ssl'` depending on the configured port. If no port is given and secure transport is enabled, the port is set to 587 (the common port for SMTP over TLS).
+</since>
+
+You can also use `'tls'` or `'ssl'` explicitly via the `security` key:
 
 ```php
 return [

--- a/content/1_docs/3_reference/6_system/1_options/0_panel/cheatsheet-article.txt
+++ b/content/1_docs/3_reference/6_system/1_options/0_panel/cheatsheet-article.txt
@@ -71,7 +71,7 @@ return [
 
 ## Default Panel language
 
-You can set the default Panel language that is used before a user logs in:
+You can set the default Panel language that is used before a user logs in or when the user does not have a valid language configured:
 
 ```php "/site/config/config.php"
 return [
@@ -80,6 +80,10 @@ return [
   ]
 ];
 ```
+
+<since v="3.5.1">
+If the Panel language is not configured, Kirby will default to English on single-language sites and the default content language on multi-language sites.
+</since>
 
 ## KirbyText/Markdown
 
@@ -122,5 +126,3 @@ return [
 ];
 ```
 </since>
-
-


### PR DESCRIPTION
✅ = Documented on the `release/3.5.1` branch

| ✅ | Issue/Feature | Related PR | Assignees | Documenting Commit |
| :-- | :--| :-- | :-- | :-- |
| ✅ | `$auth->status()` object | https://github.com/getkirby/kirby/pull/3022 | @lukasbestle | 5726a5aa70ace90b17e16cbbe4744425299f387b |
| ✅ | Extendable layout settings | https://github.com/getkirby/kirby/pull/3018 | @afbora | d0a8cd9 e9055c5 |
| ✅ | New default for the `panel.language` option | https://github.com/getkirby/kirby/pull/3025 | @lukasbestle | c1cc57d3b5b2530ebee471ed9bf869979f605148  |
| ✅ | Reintroduce date field `format` option | https://github.com/getkirby/kirby/pull/3029 | @distantnative | automatically documented |
| ✅ | 12-column layout field | https://github.com/getkirby/kirby/pull/3066 | @afbora | d3045a737da6c8effa41f6459d4bab0298f3fb6b |
| ✅ | Email security option | https://github.com/getkirby/kirby/pull/3072 | @lukasbestle  | 0e1900d3c1ec1ba0ca984259a4693c02e498489f |