### PR TITLE
3.5.0 release: metion date field breaking change

### DIFF
--- a/content/releases/3-5/v35.txt
+++ b/content/releases/3-5/v35.txt
@@ -101,6 +101,9 @@ Traditionally, we combine patch and minor releases though and never really need 
 
 With this release **we drop support for PHP&nbsp;7.2**, which has reached end of life. But we also introduce support for the brand new stable version of **PHP&nbsp;8.0**, which has been released on December 1st.
 
+#### Date field `format` option
+3.5.0 is dropping the `format` option of the date field. This is a breaking change which we will (link: https://github.com/getkirby/kirby/issues/3026 text: reverse in 3.5.1).
+
 ----
 Deprecated:
 


### PR DESCRIPTION
<img width="1240" alt="Screen Shot 2020-12-22 at 11 01 52" src="https://user-images.githubusercontent.com/3788865/102876163-20e14b00-4445-11eb-8198-8b59061e52e1.png">
