### PR TITLE
Update suggested folder structure for custom block plugins

### DIFF
--- a/content/1_docs/3_reference/7_plugins/1_extensions/0_blocks/extension.txt
+++ b/content/1_docs/3_reference/7_plugins/1_extensions/0_blocks/extension.txt
@@ -254,10 +254,10 @@ As a first step, register the custom snippet and blueprint in the index.php of y
 
 Kirby::plugin('your-project/button-block', [
   'blueprints' => [
-    'blocks/button' => __DIR__ . '/blueprints/button.yml'
+    'blocks/button' => __DIR__ . '/blueprints/blocks/button.yml'
   ],
   'snippets' => [
-    'blocks/button' => __DIR__ . '/snippets/button.php'
+    'blocks/button' => __DIR__ . '/snippets/blocks/button.php'
   ]
 ]);
 ```
@@ -266,7 +266,7 @@ Then, add the blueprint definition and the snippet code in their respective file
 
 ### Blueprint
 
-```yaml "/site/plugins/button/blueprints/button.yml"
+```yaml "/site/plugins/button/blueprints/blocks/button.yml"
 name: Button
 icon: bolt
 fields:
@@ -278,7 +278,7 @@ fields:
 
 ### Snippet
 
-```php "/site/plugins/button/snippets/button.php"
+```php "/site/plugins/button/snippets/blocks/button.php"
 <a class="btn" href="<?= $block->link()->toUrl() ?>">
   <?= $block->text()->html() ?>
 </a>


### PR DESCRIPTION
I suggest that the default folder structure in the docs should mimic Kirby's own internal folder structure. Otherwise it might be confusing for some people, why one nested folder level is missing in the docs. It doesn't matter in terms of functionality, but I still think this should be "best practice".