### PR TITLE
Redirects: easier to manage

### DIFF
--- a/content/releases/link.txt
+++ b/content/releases/link.txt
@@ -1,0 +1,1 @@
+Link: https://github.com/getkirby/kirby/releases

--- a/site/config/redirects.php
+++ b/site/config/redirects.php
@@ -1,0 +1,33 @@
+<?php
+
+return [
+    // Simple
+    'docs/guide/installation'         => 'docs/guide/quickstart',
+    'reference/(:all?)'               => 'docs/reference/$1',
+    'docs/cheatsheet/(:all?)'         => 'docs/reference/$1',
+    'docs/toolkit/(:all?)'            => 'docs/reference/$1',
+    'docs/cookbook/migration/sites'   => 'docs/cookbook/setup/migrate-site',
+    'docs/cookbook/migration/files'   => 'docs/cookbook/setup/migrate-files',
+    'docs/cookbook/migration/users'   => 'docs/cookbook/setup/migrate-users',
+    'docs/cookbook/migration/plugins' => 'docs/cookbook/setup/migrate-plugins',
+    'v3'                              => 'releases/3.0',
+    'v35'                             => 'releases/3.5',
+    'blog/kosmos-(:any)'              => 'kosmos/$1',
+    'made-with-kirby-and-love'        => 'love',
+
+    // With logic
+    'docs/reference/(:any)/(:all?)' => function ($group, $path = null) {
+        if ($page = page('docs/reference')->grandChildren()->listed()->findBy('uid', $group)) {
+            return $page->id() . '/'. $path;
+        }
+        
+        return 'error';
+    },
+    'docs/cookbook/(:any)/(:all)'     => function ($category, $uid) {
+        if ($page = page('docs/cookbook')->grandChildren()->listed()->findBy('uid', $uid)) {
+            return $page->url();
+        }
+        
+        return 'error';
+    }
+];

--- a/site/config/routes.php
+++ b/site/config/routes.php
@@ -1,22 +1,6 @@
 <?php
 
 return [
-
-    /**
-     * New routes
-     */
-    [
-        'pattern' => 'reference/(:all?)',
-        'action'  => function ($path = null) {
-            go('docs/reference/' . $path);
-        }
-    ],
-    [
-        'pattern' => 'made-with-kirby-and-love',
-        'action'  => function () {
-            go('love');
-        }
-    ],
     [
         'pattern' => 'hooks/clean',
         'method'  => 'GET|POST',
@@ -30,78 +14,6 @@ return [
             go();
         }
     ],
-
-    /**
-     * Legacy redirects
-     */
-    [
-        'pattern' => 'docs/guide/installation',
-        'action'  => function () {
-            go('docs/guide/quickstart');
-        }
-    ],
-    [
-        'pattern' => 'docs/reference/(:any)/(:all?)',
-        'action'  => function ($group, $path = null) {
-            if ($page = page('docs/reference/' . $group . '/' . $path)) {
-                return $page;
-            }
-
-            if ($page = page('docs/reference')->grandChildren()->listed()->findBy('uid', $group)) {
-                go($page->id() . '/'. $path);
-            }
-
-            go('error');
-        }
-    ],
-    [
-        'pattern' => 'docs/cookbook/(:any)/(:all)',
-        'action'  => function ($category, $uid) {
-            $path = $category . '/' . $uid;
-
-            if ($page = page('docs/cookbook/' . $path)) {
-                return $page;
-            }
-
-            $aliases = [
-                'migration/sites' => 'setup/migrate-site',
-                'migration/files' => 'setup/migrate-files',
-                'migration/users' => 'setup/migrate-users',
-                'migration/plugins' => 'setup/migrate-plugins',
-            ];
-
-            if ($page = page('docs/cookbook/' . ($aliases[$path] ?? $path))) {
-                go($page->url());
-            }
-
-            if ($page = page('docs/cookbook')->grandChildren()->listed()->findBy('uid', $uid)) {
-                go($page->url());
-            }
-
-            go('error');
-        }
-    ],
-    [
-        'pattern' => [
-            'docs/cheatsheet/(:all?)',
-            'docs/toolkit/(:all?)'
-        ],
-        'action'  => function ($path = null) {
-            go('docs/reference/' . $path);
-        }
-    ],
-    [
-        'pattern' => 'blog/kosmos-(:any)',
-        'action'  => function ($path = null) {
-            go('kosmos/' . $path);
-        }
-    ],
-    [
-        'pattern' => 'releases',
-        'action'  => function () {
-            return false;
-        }
-    ],
     [
         'pattern' => 'releases/(:num)\-(:num)',
         'action'  => function ($generation, $major) {
@@ -112,18 +24,6 @@ return [
         'pattern' => 'releases/(:num)\.(:num)',
         'action'  => function ($generation, $major) {
             return page('releases/' . $generation . '-' . $major);
-        }
-    ],
-    [
-        'pattern' => 'v3',
-        'action'  => function () {
-            return go('releases/3.0');
-        }
-    ],
-    [
-        'pattern' => 'v35',
-        'action'  => function () {
-            return go('releases/3.5');
         }
     ],
 ];

--- a/site/plugins/redirects/index.php
+++ b/site/plugins/redirects/index.php
@@ -1,0 +1,57 @@
+<?php
+
+use Kirby\Http\Router;
+
+/**
+ * Plugin creates redirect routes (using the `go()` helper) that only 
+ * take over if no actual page/route has been matched.
+ * 
+ * The rredirects get defined in `site/config/redirects.php` in an array 
+ * with the old pattern as key and the target page/URL as value. Placeholders
+ * can be used in the key and referenced via $1, $2, $3 in the target string. 
+ * Instead of a target string, a callback function returning that stirng can 
+ * also be used.
+ *
+ * @author    Nico Hoffmann <nico@getkirby.com>
+ * @link      https://getkirby.com
+ * @license   MIT
+ */
+
+Kirby::plugin('getkirby/redirects', [
+    'hooks' => [
+            'route:after' => function ($route, $path, $method, $result, $final) {
+                    // only if call didn't match any route and is final
+                    if ($final === true && empty($result) === true) {
+
+                        // load redirects definition
+                        $root      = kirby()->root('config');
+                        $redirects = require $root . '/redirects.php';
+
+                        // turn redirects into routes array
+                        $routes = array_map(function($from, $to) {
+                            return [
+                                'pattern' => $from,
+                                'action'  => function (...$parameters) use ($to) {
+
+                                    // resolve callback for target
+                                    if (is_callable($to) === true) {
+                                        $to = $to(...$parameters);
+                                    }
+
+                                    // fill placeholders
+                                    foreach ($parameters as $i => $parameter) {
+                                        $to = str_replace('$' . ($i + 1), $parameter, $to);
+                                    }
+
+                                    return go($to);
+                                }
+                            ];
+                        }, array_keys($redirects), $redirects);
+
+                        // run router on redirects routes
+                        $router = new Router($routes);
+                        return $router->call($path, $method);
+                    }
+            }
+    ]
+]);


### PR DESCRIPTION
A little plugin that allows us to register redirects simpler in `site/config/redirects.php`.
Also those only get checked if no actual page exists, so taking a bit load off the main router.

This will help us a lot to easily set up redirects when we want to reorder the site a bit, e.g. the reference structure, cookbook categories...