### PR TITLE
Add charset UTF-8 to locale string

### DIFF
--- a/content/1_docs/1_guide/7_languages/1_introduction/guide.txt
+++ b/content/1_docs/1_guide/7_languages/1_introduction/guide.txt
@@ -57,7 +57,7 @@ return [
   'code' => 'en',
   'default' => true,
   'direction' => 'ltr',
-  'locale' => 'en_US',
+  'locale' => 'en_US.utf-8',
   'name' => 'English',
 ];
 ```
@@ -107,7 +107,7 @@ return [
     'default' => true,
     'direction' => 'ltr',
     'locale' => [
-        'LC_ALL' => 'en_GB'
+        'LC_ALL' => 'en_GB.utf-8'
     ],
     'name' => 'English',
     'translations' => [
@@ -132,7 +132,7 @@ return [
   'code' => 'en',
   'default' => true,
   'direction' => 'ltr',
-  'locale' => 'en_US',
+  'locale' => 'en_US.utf-8',
   'name' => 'English',
   'url' => 'https://example.com'
 ];
@@ -145,7 +145,7 @@ return [
   'code' => 'de',
   'default' => false,
   'direction' => 'ltr',
-  'locale' => 'de_DE',
+  'locale' => 'de_DE.utf-8',
   'name' => 'Deutsch',
   'url' => 'https://example.de'
 ];


### PR DESCRIPTION
On my machine (Ubuntu, NginX, PHP 7.4) the strftime-function only translates successfully when the ".utf-8" extension is present in the locale string.