### PR TITLE
Reference lookup also on local

### DIFF
--- a/site/config/config.getkirby.com.php
+++ b/site/config/config.getkirby.com.php
@@ -17,6 +17,5 @@ return [
     ],
     'keycdn' => [
         'domain' => 'https://assets.getkirby.com',
-    ],
-    'referenceLookup' => true
+    ]
 ];

--- a/site/config/config.getkirby.test.php
+++ b/site/config/config.getkirby.test.php
@@ -1,6 +1,5 @@
 <?php
 
 return [
-    'debug' => true,
-    'referenceLookup' => false
+    'debug' => true
 ];

--- a/site/plugins/site/helpers.php
+++ b/site/plugins/site/helpers.php
@@ -167,10 +167,6 @@ function icon(string $name, bool $return = false, array $attr = null)
 
 function referenceLookup(string $class)
 {
-    if (option('referenceLookup') === false) {
-        return false;
-    }
-
     $roots = [
         'docs/reference/objects',
         'docs/reference/tools',


### PR DESCRIPTION
I don't know why we ever deactivated it, but it seems to work without issues also on local. I would suggest to streamline and remove that option.