### PR TITLE
doc: details on creating translated pages via API

### DIFF
--- a/content/1_docs/3_reference/8_api/0_pages/5_children-create/endpoint.txt
+++ b/content/1_docs/3_reference/8_api/0_pages/5_children-create/endpoint.txt
@@ -8,6 +8,11 @@ Auth: pages.create
 ----
 Text:
 
+
+## Creating translated pages
+
+A request to this endpoint will **always** create a page with the default language. The `x-language` header setting will have no effect on this endpoint. To create a new page with translations, create the default language version first and then make another (link: docs/reference/api/pages/update text:`PATCH` request) on the newly created page including the proper `x-language` header to update its translated content.
+
 ## Post parameters
 
 (docs: api/page-create-data)


### PR DESCRIPTION
I learned this today on the forum: https://forum.getkirby.com/t/x-language-header-in-rest-api-calls-is-ignored/

Should definitely be part of the documentation in my opinion.

Let me know if this needs more polishing or any other corrections you might have.