### PR TITLE
Moves the heading titles outside <since> tag

### DIFF
--- a/content/1_docs/3_reference/3_panel/2_presets/0_files/cheatsheet-article.txt
+++ b/content/1_docs/3_reference/3_panel/2_presets/0_files/cheatsheet-article.txt
@@ -60,10 +60,9 @@ preset: files
 layout: cards
 ```
 
-<since v="3.3.3">
-
 ### Image
 
+<since v="3.3.3">
 ```yaml
 title: Gallery section
 preset: files

--- a/content/1_docs/3_reference/3_panel/3_fields/0_info/cheatsheet-article.txt
+++ b/content/1_docs/3_reference/3_panel/3_fields/0_info/cheatsheet-article.txt
@@ -70,9 +70,9 @@ fields:
 
 (screenshot: info-negative.png)
 
-<since v="3.3.4">
 ### Disable theming
 
+<since v="3.3.4">
 You can disable the infobox theme entirely to show neutral text.
 
 ```yaml

--- a/content/1_docs/3_reference/3_panel/4_sections/0_fields/section.txt
+++ b/content/1_docs/3_reference/3_panel/4_sections/0_fields/section.txt
@@ -33,9 +33,10 @@ sections:
         label: Text
         type: textarea
 ```
-<since v="3.3.0">
+
 ## Section shortcuts
 
+<since v="3.3.0">
 For simple sections that are only used once per blueprint, you can use shortcuts. In its most basic form, a `fields` section consists of the section type as name, and a set of fields:
 
 ```yaml

--- a/content/1_docs/3_reference/3_panel/4_sections/0_files/section.txt
+++ b/content/1_docs/3_reference/3_panel/4_sections/0_files/section.txt
@@ -25,9 +25,9 @@ sections:
     type: files
     template: gallery
 ```
-<since v="3.3.0">
 ## Section shortcuts
 
+<since v="3.3.0">
 For simple sections that are only used once per blueprint, you can use shortcuts. In its most basic form, a `files` section consists of the section type as name, and  `true` as its value.
 
 ```yaml
@@ -42,7 +42,7 @@ These shortcuts can be extended with other section properties as needed, for exa
 ```yaml
 sections:
 
-  files: 
+  files:
     headline: My Files
     template: cover
 ```

--- a/content/1_docs/3_reference/3_panel/4_sections/0_info/section.txt
+++ b/content/1_docs/3_reference/3_panel/4_sections/0_info/section.txt
@@ -176,9 +176,9 @@ sections:
       Just upload whatever you want. We get sued anyway.
 ```
 
-<since v="3.3.4">
 ### Disable theming
 
+<since v="3.3.4">
 You can disable the infobox theme entirely to show neutral text.
 
 ```yaml

--- a/content/1_docs/3_reference/4_objects/0_file/0_srcset/method.txt
+++ b/content/1_docs/3_reference/4_objects/0_file/0_srcset/method.txt
@@ -17,10 +17,9 @@ $image->srcset([
 ]);
 ```
 
-<since v="3.2.0">
-
 ### More complex sizes options
 
+<since v="3.2.0">
 The `$sizes` parameter also accepts an associated array of options:
 
 ```php

--- a/content/1_docs/3_reference/4_objects/0_kirby/0_email/method.txt
+++ b/content/1_docs/3_reference/4_objects/0_kirby/0_email/method.txt
@@ -31,9 +31,9 @@ try {
 'replyTo' => 'jane@supercompany.com'
 ```
 
-<since v="3.3.2">
-
 #### `from` with name
+
+<since v="3.3.2">
 ```php
 'from'     => 'no-reply@supercompany.com',
 'fromName' => 'Jane Doe'
@@ -89,7 +89,7 @@ $from = new \Kirby\Cms\User([
 
 ```php
 'to' => [
-    'jane@doe.com', 
+    'jane@doe.com',
     'mark@otto.com'
 ],
 ```

--- a/content/1_docs/3_reference/6_system/1_options/0_auth/cheatsheet-article.txt
+++ b/content/1_docs/3_reference/6_system/1_options/0_auth/cheatsheet-article.txt
@@ -31,9 +31,9 @@ return [
 ];
 ```
 
-<since v="3.5.0">
 ## Login methods
 
+<since v="3.5.0">
 The `auth.methods` option controls the available login methods for the Panel and the API.
 
 The available options are:

--- a/content/1_docs/3_reference/7_plugins/1_extensions/0_hooks/extension.txt
+++ b/content/1_docs/3_reference/7_plugins/1_extensions/0_hooks/extension.txt
@@ -46,9 +46,9 @@ Kirby::plugin('your/plugin', [
 ]);
 ```
 
-<since v="3.4.0">
 ### Wildcard hooks
 
+<since v="3.4.0">
 If you want to register the same hook for multiple events, you can register a wildcard hook (either in your config or in a plugin):
 
 ```php "/site/config/config.php"
@@ -106,9 +106,9 @@ $username = $this->user()->username();
 $role     = $this->user()->role();
 ```
 
-<since v="3.4.0">
 ## Hook arguments
 
+<since v="3.4.0">
 Since Kirby 3.4.0, the hook arguments are no longer provided by position, but by variable name (similar to (link: docs/guide/templates/controllers#accessing-kirby-objects-in-your-controller text: controllers)). This allows you to request just the arguments you need in any order. All arguments that are not available will be passed as `null`:
 
 ```php "/site/config/config.php"


### PR DESCRIPTION
In order for the `<since>` to appear in the right place, the section titles/headings should be outside the `<since>` tag.