### PR TITLE
Code: fix overflowing shadow on Copy #1070

### DIFF
--- a/www/assets/css/legacy.css
+++ b/www/assets/css/legacy.css
@@ -757,7 +757,6 @@ h6 code,
   font-size: 14px;
   letter-spacing: 0;
   line-height: 1.7142857143;
-  margin-bottom: 1.5rem;
 }
 
 .code ::selection,
@@ -1017,6 +1016,7 @@ h6 code,
 :not(.codeblock-figure) > .code-toolbar {
   overflow: hidden;
   position: relative;
+  margin-bottom: 1.5rem;
 }
 
 .code-toolbar .toolbar {


### PR DESCRIPTION
Fixes this:
<img width="561" alt="100333614-190fc180-2fd3-11eb-9a0b-0b2615e8a992" src="https://user-images.githubusercontent.com/3788865/104843975-b699ba00-58cd-11eb-968b-19a52ded2736.png">
