### PR TITLE
Adds video tag extended plugin

### DIFF
--- a/site/plugins/video-tag-extended/index.php
+++ b/site/plugins/video-tag-extended/index.php
@@ -24,7 +24,7 @@ Kirby::plugin('getkirby/video-tag-extended', [
             ],
             'html' => function ($tag) {
                 // available attributes
-                $attrs = KirbyTag::$types[$tag->type];
+                $attrs = KirbyTag::$types[$tag->type]['attr'];
 
                 // gets global video tag options
                 $options = $tag->kirby()->option('kirbytext.video', []);

--- a/site/plugins/video-tag-extended/index.php
+++ b/site/plugins/video-tag-extended/index.php
@@ -55,10 +55,10 @@ Kirby::plugin('getkirby/video-tag-extended', [
 
                     return [
                         'autoplay' => $autoplay = Str::toType($tag->autoplay, 'bool'),
-                        'controls' => Str::toType($tag->controls !== null ? $tag->controls : true, 'bool'),
+                        'controls' => Str::toType($tag->controls ?? true, 'bool'),
                         'height'   => $tag->height,
                         'loop'     => Str::toType($tag->loop, 'bool'),
-                        'muted'    => Str::toType($tag->muted !== null ? $tag->muted : $autoplay, 'bool'),
+                        'muted'    => Str::toType($tag->muted ?? $autoplay, 'bool'),
                         'poster'   => $tag->poster,
                         'preload'  => $tag->preload,
                         'width'    => $tag->width

--- a/site/plugins/video-tag-extended/index.php
+++ b/site/plugins/video-tag-extended/index.php
@@ -30,11 +30,9 @@ Kirby::plugin('getkirby/video-tag-extended', [
                 $options = $tag->kirby()->option('kirbytext.video', []);
 
                 // injects default values
-                // applies only string options (ignored youtube and vimeo options)
-                // and defined attributes to safely update tag props
+                // applies only defined attributes to safely update tag props
                 foreach ($options as $option => $value) {
                     if (
-                        is_string($option) === true &&
                         in_array($option, $attrs) === true &&
                         (isset($tag->{$option}) === false || $tag->{$option} === null)
                     ) {

--- a/site/plugins/video-tag-extended/index.php
+++ b/site/plugins/video-tag-extended/index.php
@@ -1,0 +1,119 @@
+<?php
+
+use Kirby\Cms\App as Kirby;
+use Kirby\Text\KirbyTag;
+use Kirby\Toolkit\F;
+use Kirby\Toolkit\Html;
+use Kirby\Toolkit\Str;
+
+Kirby::plugin('getkirby/video-tag-extended', [
+    'tags' => [
+        'video' => [
+            'attr' => [
+                'autoplay',
+                'caption',
+                'controls',
+                'class',
+                'height',
+                'loop',
+                'muted',
+                'poster',
+                'preload',
+                'style',
+                'width',
+            ],
+            'html' => function ($tag) {
+                // available attributes
+                $attrs = KirbyTag::$types[$tag->type];
+
+                // gets global video tag options
+                $options = $tag->kirby()->option('kirbytext.video', []);
+
+                // injects default values
+                // applies only string options (ignored youtube and vimeo options)
+                // and defined attributes to safely update tag props
+                foreach ($options as $option => $value) {
+                    if (
+                        is_string($option) === true &&
+                        in_array($option, $attrs) === true &&
+                        (isset($tag->{$option}) === false || $tag->{$option} === null)
+                    ) {
+                        $tag->{$option} = $value;
+                    }
+                }
+
+                // generates tag options helper
+                $generateTagOptions = function ($tag) {
+                    // checks local poster file and handle
+                    if (
+                        empty($tag->poster) === false &&
+                        Str::startsWith($tag->poster, 'http://') !== true &&
+                        Str::startsWith($tag->poster, 'https://') !== true
+                    ) {
+                        if ($poster = $tag->file($tag->poster)) {
+                            $tag->poster = $poster->url();
+                        }
+                    }
+
+                    return [
+                        'autoplay' => $autoplay = Str::toType($tag->autoplay, 'bool'),
+                        'controls' => Str::toType($tag->controls !== null ? $tag->controls : true, 'bool'),
+                        'height'   => $tag->height,
+                        'loop'     => Str::toType($tag->loop, 'bool'),
+                        'muted'    => Str::toType($tag->muted !== null ? $tag->muted : $autoplay, 'bool'),
+                        'poster'   => $tag->poster,
+                        'preload'  => $tag->preload,
+                        'width'    => $tag->width
+                    ];
+                };
+
+                // handles local video file
+                if (
+                    Str::startsWith($tag->value, 'http://') !== true &&
+                    Str::startsWith($tag->value, 'https://') !== true
+                ) {
+                    if ($tag->file = $tag->file($tag->value)) {
+                        $options = $generateTagOptions($tag);
+                        $source = Html::tag('source', null, [
+                            'src'  => $tag->file->url(),
+                            'type' => $tag->file->mime()
+                        ]);
+                        $video = Html::tag('video', [$source], $options);
+                    }
+                } else {
+                    // first handles supported video providers as youtube, vimeo, etc
+                    try {
+                        $video = Html::video(
+                            $tag->value,
+                            $options,
+                            [
+                                'height' => $tag->height,
+                                'width'  => $tag->width
+                            ]
+                        );
+                    } catch (Exception $e) {
+                        // if not one of the supported video providers
+                        // it checks if there is a valid remote video file
+                        $extension = F::extension($tag->value);
+                        $type      = F::extensionToType($extension);
+                        $mime      = F::extensionToMime($extension);
+
+                        if ($type === 'video') {
+                            $options = $generateTagOptions($tag);
+                            $source = Html::tag('source', null, [
+                                'src'  => $tag->value,
+                                'type' => $mime
+                            ]);
+                            $video = Html::tag('video', [$source], $options);
+                        }
+                    }
+                }
+
+                return Html::figure([$video ?? ''], $tag->caption, [
+                    'class' => $tag->class ?? 'video',
+                    'style' => $tag->style
+                ]);
+            }
+        ]
+    ]
+]);


### PR DESCRIPTION
Supported local and remote video files by extending video tag that supporting only youtube and vimeo videos. Youtube and vimeo features have not been changed.

### New Attributes:
- autoplay
- controls (default: true)
- loop
- muted *
- poster
- preload (auto, metadata, none)

_* muted will enabled if autoplay enabled and muted is not defined_

I might have exaggerated a little 😅 

Usages:

````markdown
# local
(video: local-video.mp4)

# remote
(video: https://www.getkirby.com/sample-video.mp4)

# example 1
(video: local-video.mp4  autoplay: true)

# example 2
(video: local-video.mp4 controls: false autoplay: true loop: true)

# example 3
(video: local-video.mp4 poster: cover.jpg)

# example 4
(video: local-video.mp4 preload: auto)

# example 5
(video: https://www.getkirby.com/sample-video.mp4 muted: true controls: false autoplay: true)

# example 6
(video: local-video.mp4 poster: https://www.getkirby.com/sample-cover.jpg)

````