### PR TITLE
Fix cookbook I18n method reference

### DIFF
--- a/content/1_docs/2_cookbook/5_i18n/0_using-variables-in-language-strings/recipe.txt
+++ b/content/1_docs/2_cookbook/5_i18n/0_using-variables-in-language-strings/recipe.txt
@@ -51,7 +51,7 @@ return [
 ];
 ```
 
-In your code, you can now access the translation strings and replace your placeholders using the [`I18n::template()` method](docs/reference/tools/i18n/template) like this:
+In your code, you can now access the translation strings and replace your placeholders using the [`I18n::template()` method](/docs/reference/tools/i18n/template) like this:
 
 ```php
 echo I18n::template('file.success', null, [


### PR DESCRIPTION
Resolve an issue in the cookbook about I18n placeholders, where the link to the reference
page is broken due to a missing forward slash