### PR TITLE
Change Maintainer and Name of git-commit-and-push-content Plugin

### DIFF
--- a/content/plugins/blankogmbh/plugin-developer.txt
+++ b/content/plugins/blankogmbh/plugin-developer.txt
@@ -1,1 +1,0 @@
-Title: Blanko GmbH

--- a/content/plugins/thathoff/git-content/plugin.txt
+++ b/content/plugins/thathoff/git-content/plugin.txt
@@ -1,8 +1,8 @@
-Title: Git Commit And Push Content
+Title: Git Content
 
 ----
 
-Repository: https://github.com/blankogmbh/kirby-git-commit-and-push-content
+Repository: https://github.com/thathoff/kirby-git-content
 
 ----
 


### PR DESCRIPTION
The maintainer and name of the git-commit-and-push-content plugin has changed. The new plugin name is git-content and the new maintainer is thathoff.