### PR TITLE
add option 'read' to the reference of blueprints.users.permissions.pages

### DIFF
--- a/content/1_docs/3_reference/3_panel/1_blueprints/0_user/cheatsheet-article.txt
+++ b/content/1_docs/3_reference/3_panel/1_blueprints/0_user/cheatsheet-article.txt
@@ -101,6 +101,7 @@ permissions:
 | `delete` | `true`/`false` |
 | `duplicate` | `true`/`false` |
 | `preview` | `true`/`false` |
+| `read` | `true`/`false` |
 | `update` | `true`/`false` |
 
 #### Example: Prevent deleting and creating pages and changing their template


### PR DESCRIPTION
after a while i found out, that even more permissions are listet in the [guides-section](https://getkirby.com/docs/guide/users/permissions), than in the reference.
maybe the reference should also link to that site?