### PR TITLE
Suggest values for `step.unit` option in time field

### DIFF
--- a/content/1_docs/3_reference/3_panel/3_fields/0_time/reference-article.txt
+++ b/content/1_docs/3_reference/3_panel/3_fields/0_time/reference-article.txt
@@ -77,7 +77,7 @@ If you specify the `display` option, this will take priority (whether it include
 ## Step
 
 <since v="3.5.0">
-The `step` option allows you to define intervals of valid values. Any input to the field gets rounded to the nearest interval step. The default is 5 minutes.
+The `step` option allows you to define intervals of valid values. Any input to the field gets rounded to the nearest interval step. The default is 5 minutes. Possible values for unit are `hour`, `minute` and `second`.
 
 ```yaml
 step:


### PR DESCRIPTION
It is not really obvious how to set the time field to seconds and you would have to guess, that you can do
```yaml
step: second
```
To make that more clear, I suggest to add:
> Possible values for unit are `hour`, `minute` and `second`.