### PR TITLE
feat: add info for unremovable draft status in page blueprints

### DIFF
--- a/content/1_docs/3_reference/3_panel/1_blueprints/0_page/reference-article.txt
+++ b/content/1_docs/3_reference/3_panel/1_blueprints/0_page/reference-article.txt
@@ -95,7 +95,9 @@ If you use a sorting scheme other than default sorting by number, i.e. automatic
 </info>
 ## Statuses
 
-With the `status` option, you define the page status you want to allow for the page. You can also change their label and description. This option gives you a lot of flexibility how you want to use page status in your website.
+With the `status` option, you define the page statuses you want to allow for the page. You can also change their label and description. This option gives you a lot of flexibility how you want to use page status in your website.
+
+<info>The `draft` status of a page can not be removed or disabled – only its label and description can be changed.</info>
 
 ### Simple example
 


### PR DESCRIPTION
* add info that the `draft` status of a page can not be removed or disabled. so far the description suggests that all statuses can be removed – which is not the case and can be very misleading