### PR TITLE
Only highlight Kirby classes with reference link

### DIFF
--- a/site/plugins/site/src/Types/Type.php
+++ b/site/plugins/site/src/Types/Type.php
@@ -105,27 +105,17 @@ class Type
             return static::tag($type, $type);
         }
 
-        // Assume, it’s a class name
-        if (preg_match('/^[A-Z]/', $type) === 1) {
-            // Namespaced class name, look whether it’s a Kirby classs
-            if ($class = ReferenceClassPage::findByName($type)) {
-                return static::tag(
-                    $type,
-                    'object',
-                    $withLink ? $class->url() : null
-                );
-            }
-
-            // Some class that exists in PHP in the global namespace. The
-            // seconds check is done to ensure correct case, as `class_exists()`
-            // is not case-sensitive.
-            if (
-                isset($url) === false &&
-                class_exists($type) === true &&
-                (new ReflectionClass($type))->getName() === $type
-            ) {
-                return static::tag($type, 'class');
-            }
+        // Assume, it’s a class name,
+        // look whether it’s a Kirby classs
+        if (
+            preg_match('/^[A-Z]/', $type) === 1 &&
+            $class = ReferenceClassPage::findByName($type)
+        ) {
+            return static::tag(
+                $type,
+                'object',
+                $withLink ? $class->url() : null
+            );
         }
 
         // Probably a code example (not a datatype),


### PR DESCRIPTION
Have been wondering whether it is better to only add the yellow color to classes from Kirby that then also link to the Reference. So leave all generic classes gray. 

Old:
<img width="673" alt="Screen Shot 2021-04-15 at 09 22 08" src="https://user-images.githubusercontent.com/3788865/114830224-4e734b00-9dcc-11eb-91bd-a7f48cf0a61d.png">

New:
<img width="666" alt="Screen Shot 2021-04-15 at 09 22 17" src="https://user-images.githubusercontent.com/3788865/114830238-5337ff00-9dcc-11eb-88b7-20838502cbed.png">

Would simplify the parsing. But unsure myself.