### PR TITLE
Adds blade template engine sample codes to `For developers`

### DIFF
--- a/content/features/1_developers/features-for-developers.txt
+++ b/content/features/1_developers/features-for-developers.txt
@@ -101,6 +101,31 @@ twigTemplate:
 ```
 
 ----
+
+bladeTemplate:
+
+```php
+@extends('layouts.default')
+
+@section('content')
+<article class="album">
+  <h1>{{ $page->title() }}</h1>
+  <figure class="cover">
+    {!! $cover->resize(800, 600) !!}
+  </figure>
+  <div class="text">
+    {!! $page->text()->kirbytext() !!}
+  </div>
+  <ul class="gallery">
+    @foreach($gallery as $image)
+    <li>{!! $image->crop(300) !!}</li>
+    @endforeach
+  </ul>
+</article>
+@endsection
+```
+
+----
 Api:
 
 ```yaml "/api/pages/notes/children"

--- a/site/snippets/templates/features-for-developers/templating-figure.php
+++ b/site/snippets/templates/features-for-developers/templating-figure.php
@@ -7,6 +7,7 @@
 <select aria-label="Switch the template engine example" class="template-select mb-3">
   <option value="php" selected>PHP template</option>
   <option value="twig">Twig template</option>
+  <option value="blade">Blade template</option>
 </select>
 
 <div id="php" data-template>
@@ -18,6 +19,14 @@
   </div>
   <div class="font-mono text-xs color-gray-700">
     <a href="/plugins/mgfagency/twig"><strong class="font-normal color-black link">Kirby Twig plugin</strong> by Christian Zehetner</a>
+  </div>
+</div>
+<div id="blade" data-template class="hidden">
+  <div class="mb-3">
+    <?= $page->bladeTemplate()->kt() ?>
+  </div>
+  <div class="font-mono text-xs color-gray-700">
+    <a href="/plugins/afbora/blade"><strong class="font-normal color-black link">Kirby Blade plugin</strong> by Ahmet Bora</a>
   </div>
 </div>
 


### PR DESCRIPTION
![screen-capture-1004-For developers - Kirby CMS-dev getkirby test](https://user-images.githubusercontent.com/3393422/114875776-4fc16980-9e06-11eb-8481-78176a5e9ed6.png)
