### PR TITLE
Additions to banner PR

### DIFF
--- a/assets/css/site/menu.css
+++ b/assets/css/site/menu.css
@@ -35,23 +35,6 @@
   fill: currentColor;
 }
 
-/** Banner **/
-.banner {
-  position: absolute;
-  top: 5rem;
-  right: 0;
-  display: none;
-}
-.banner::before {
-  position: absolute;
-  top: -6px;
-  right: 4.5rem;
-  content: "";
-  border-left: 6px solid transparent;
-  border-right: 6px solid transparent;
-  border-bottom: 6px solid #fff;
-}
-
 /** Menu Toggle **/
 .menu input {
   position: absolute;
@@ -75,6 +58,15 @@
   right: .75rem;
   transform: translateY(-50%) rotate(-45deg);
   color: var(--color-gray-400);
+}
+
+/** Banner **/
+.banner {
+  display: none;
+  position: absolute;
+  padding: .5rem .75rem;
+  line-height: var(--leading-none);
+  white-space: nowrap;
 }
 
 /** Small **/
@@ -112,6 +104,16 @@
   .menu-steps {
     display: flex;
     align-items: center;
+  }
+
+  .header[data-template=home] .banner,
+  .header[data-template=buy] .banner {
+    display: block;
+    top: 8.5rem;
+    top: clamp(8.5rem, 22vw, 10rem);
+  }
+  .banner a::after {
+    content: " →"
   }
 }
 
@@ -180,5 +182,18 @@
 
   .banner {
     display: block;
+    top: 5rem;
+    right: 0;
+    background: var(--color-white);
+    box-shadow: var(--shadow-2xl);
+  }
+  .banner::before {
+    position: absolute;
+    top: -6px;
+    right: 4.5rem;
+    content: "";
+    border-left: 6px solid transparent;
+    border-right: 6px solid transparent;
+    border-bottom: 6px solid #fff;
   }
 }

--- a/site/snippets/layouts/banner.php
+++ b/site/snippets/layouts/banner.php
@@ -1,5 +1,5 @@
-<aside class="banner bg-white shadow-2xl rounded text-sm">
 <?php if ($banner = banner()): ?>
+<aside class="banner text-sm">
   <?php if ($url = $banner->url()): ?>
   <a href="<?= $url ?>"><?= $banner->text() ?></a>
   <?php else: ?>

--- a/site/snippets/layouts/banner.php
+++ b/site/snippets/layouts/banner.php
@@ -1,5 +1,5 @@
-<?php if ($banner = currentBanner()): ?>
 <aside class="banner bg-white shadow-2xl rounded text-sm">
+<?php if ($banner = banner()): ?>
   <?php if ($url = $banner->url()): ?>
   <a href="<?= $url ?>"><?= $banner->text() ?></a>
   <?php else: ?>

--- a/site/snippets/layouts/header.php
+++ b/site/snippets/layouts/header.php
@@ -5,6 +5,7 @@
       <?php snippet('layouts/logo') ?>
       <?php snippet('layouts/menu') ?>
       <?php snippet('layouts/search', ['area' => $search ?? 'all']) ?>
+      <?php snippet('layouts/banner') ?>
     </div>
   </div>
 </header>

--- a/site/snippets/layouts/header.php
+++ b/site/snippets/layouts/header.php
@@ -1,4 +1,4 @@
-<header class="header mb-24">
+<header class="header mb-24" data-template="<?= $page->template() ?>">
   <?php snippet('layouts/skipper') ?>
   <div class="container">
     <div class="header-content relative flex items-center">

--- a/site/snippets/layouts/menu.php
+++ b/site/snippets/layouts/menu.php
@@ -56,9 +56,5 @@
         <a href="/buy">Buy</a>
       </li>
     </ul>
-
-    <?php if (Kirby\Layout\Layout::$name !== 'reference'): ?>
-    <?php snippet('layouts/banner') ?>
-    <?php endif ?>
   </nav>
 </div>

--- a/site/snippets/templates/features-for-developers/templating-figure.php
+++ b/site/snippets/templates/features-for-developers/templating-figure.php
@@ -10,10 +10,10 @@
   <option value="blade">Blade template</option>
 </select>
 
-<div id="php" data-template>
+<div id="php" data-templating>
   <?= $page->phpTemplate()->kt() ?>
 </div>
-<div id="twig" data-template class="hidden">
+<div id="twig" data-templating class="hidden">
   <div class="mb-3">
     <?= $page->twigTemplate()->kt() ?>
   </div>
@@ -21,7 +21,7 @@
     <a href="/plugins/mgfagency/twig"><strong class="font-normal color-black link">Kirby Twig plugin</strong> by Christian Zehetner</a>
   </div>
 </div>
-<div id="blade" data-template class="hidden">
+<div id="blade" data-templating class="hidden">
   <div class="mb-3">
     <?= $page->bladeTemplate()->kt() ?>
   </div>
@@ -32,7 +32,7 @@
 
 <script>
 const select    = document.querySelector(".template-select");
-const templates = [...document.querySelectorAll("[data-template]")];
+const templates = [...document.querySelectorAll(".template-select ~ [data-templating]")];
 
 const changeTemplate = () => {
   templates.forEach(x => x.classList.add("hidden"));


### PR DESCRIPTION
I've made some small changes:
- code cosmetics
- embedding the snippet in `layouts/header.php`, so we don't need to check for Reference layout since this layout doesn't use this snippet, while all others do

I also added support for showing the banner on mobile:
<img width="458" alt="Screen Shot 2021-04-17 at 10 30 28" src="https://user-images.githubusercontent.com/3788865/115106995-7697b100-9f68-11eb-9386-85e93a243b0b.png">

- only on `home` and `buy` since it is a lot more attention grabbing and would be a bit annoying to have it on each page above the title
- on those I feel it works though