### PR TITLE
`author` kirbytag

### DIFF
--- a/content/docs/2_cookbook/3_templating/0_shared-controllers/cookbook-recipe.txt
+++ b/content/docs/2_cookbook/3_templating/0_shared-controllers/cookbook-recipe.txt
@@ -16,6 +16,8 @@ Controllers are an excellent tool to keep your templates and blueprints clean an
 
 Luckily for us, creating a shared controller is an easy task in Kirby 3.
 
+(author: Manu Moreale link: https://manuelmoreale.com)
+
 ## A simple example
 
 We'll use the `<title>` and `<meta name="description">` tags as an example. The easiest way to add those two tags to our site would be to add them directly into the `header.php` snippet. Something like this:
@@ -199,7 +201,3 @@ return function ($page, $pages, $site, $kirby) {
 
 };
 ```
-
-## Author
-
-This cookbook recipe was written by (link: https://manuelmoreale.com text: Manu Moreale).

--- a/site/plugins/site/extensions/tags.php
+++ b/site/plugins/site/extensions/tags.php
@@ -30,6 +30,21 @@ $tags['image'] = [
 ];
 
 /**
+ * (author: Bastian Allgeier link: https://getkirby.com)
+ */
+$tags['author'] = [
+    'attr' => [
+        'link'
+    ],
+    'html' => function ($tag) {
+        return snippet('kirbytext/author', [
+            'name'  => $tag->value,
+            'link'  => $tag->link ?? null
+        ], true);
+    }
+];
+
+/**
  * (screencast: https://www.youtube.com/watch?v=EDVYjxWMecc title: How to install Kirby in 5 minutes)
  */
 $tags['screencast'] = [

--- a/site/snippets/kirbytext/author.php
+++ b/site/snippets/kirbytext/author.php
@@ -1,0 +1,9 @@
+<div class="pt-12">
+  <div class="box p-3 text-sm" style="color: black">
+    <span class="font-mono text-xs">Author</span>
+    <div class="h3 font-bold"><?= $name ?></div>
+    <?php if ($link ?? null): ?>
+      <a href="<?= $link ?>"><?= Url::short(Url::base($link)) ?></a>
+    <?php endif ?>
+  </div>
+</div>


### PR DESCRIPTION
Fixes #884

I don't think this styling is good yet:
<img width="1310" alt="Screen Shot 2021-04-17 at 21 17 43" src="https://user-images.githubusercontent.com/3788865/115124432-80e69900-9fc2-11eb-8d4d-166606627a79.png">


But maybe this way we can star the conversation where exactly to include these (e.g. maybe instead directly below the title), what info should be shown etc.

And whether we think a tag to be used anywhere in the site makes sense. Or if it's a field for cookbook recipes.