### PR TITLE
Larger clickable area for sidebar links

### DIFF
--- a/assets/css/site/sidebar.css
+++ b/assets/css/site/sidebar.css
@@ -23,14 +23,16 @@
   position: relative;
   font-size: var(--text-sm);
   line-height: 1;
-  padding-top: .625rem;
-  padding-bottom: .125rem;
+  padding-top: .375rem;
+  padding-bottom: .375rem;
 }
 .sidebar-menu-2 li {
-  margin-bottom: .5rem;
+  margin-bottom: 0;
 }
 .sidebar-menu-2 li > a {
   display: block;
   font-weight: normal;
   color: var(--color-gray-700);
+  padding-top: .25rem;
+  padding-bottom: .25rem;
 }


### PR DESCRIPTION
In the sidebar I'd suggest removing the `margin-bottom` from the `li` and adding some padding to the links instead.
This makes the clickable area a lot bigger and it's a big improvement for touch-enabled devices.

<img src="https://user-images.githubusercontent.com/7975568/115348933-89ea8c80-a1b3-11eb-8451-8a432703083a.png" width="454">