### PR TITLE
Fix typo in upgrade guide

### DIFF
--- a/content/docs/2_cookbook/9_setup/0_migrate-site/cookbook-recipe.txt
+++ b/content/docs/2_cookbook/9_setup/0_migrate-site/cookbook-recipe.txt
@@ -284,7 +284,7 @@ return function ($kirby) {
 ```
 
 <since v="3.1.3">
-In your route, you can also pass all arguments explicitely to the `->render()` method to make them directly accessible in the controller. (link: docs/guide/templates/controllers#arguments-from-page-render-in-route text: Read more ›)
+In your route, you can also pass all arguments explicitly to the `->render()` method to make them directly accessible in the controller. (link: docs/guide/templates/controllers#arguments-from-page-render-in-route text: Read more ›)
 </since> 
 
 ### Page status


### PR DESCRIPTION
I don't know what's going on with the other lines (these changes were done by the GitHub editor). Maybe line endings? I just wanted to fix the typo.