### PR TITLE
Docs for Kirby 3.5.5

### DIFF
--- a/content/docs/1_guide/10_authentication/1_login-methods/guide.txt
+++ b/content/docs/1_guide/10_authentication/1_login-methods/guide.txt
@@ -74,5 +74,5 @@ For security, please DO NOT forward this email.
 ```
 
 <info>
-Our default templates are translated into our Panel languages. So if you just want the text in your native language, you can (link: docs/reference/system/options/panel#default-panel-language text: switch the default Panel language) – which will then be used for the login UI and the email templates.
+Our default templates are translated into our Panel languages. Kirby will automatically pick the best language for the email text (the configured user language, the (link: docs/reference/system/options/panel#default-panel-language text: default `panel.language`) or the default site language of a multilang site). The `panel.language` option is also used for the login UI.
 </info>

--- a/content/docs/1_guide/5_templates/1_basics/guide.txt
+++ b/content/docs/1_guide/5_templates/1_basics/guide.txt
@@ -245,6 +245,10 @@ $kirby->response()->type('txt');
 $kirby->response()->type('text/plain');
 ```
 
+<info>
+The `$kirby->response()` object provides several other methods to customize the response (e.g. caching, HTTP headers and the HTTP status code). (link: docs/reference/objects/cms/responder text: Learn more in the reference ›)
+</info>
+
 ## More information
 
 - (link: docs/cookbook/templating/custom-post-types text: Custom post types)

--- a/content/docs/3_reference/1_text/0_kirbytags/0_video/reference-kirbytag.txt
+++ b/content/docs/3_reference/1_text/0_kirbytags/0_video/reference-kirbytag.txt
@@ -49,6 +49,55 @@ Embedded Vimeo video by video URL:
 (\video: http://vimeo.com/3432886)
 ```
 
+<since v="3.5.5">
+### Local and remote video
+
+You can now embed a video on local or remote server.
+
+```kirbytext
+# local
+(\video: local-video.mp4)
+
+# remote
+(\video: https://www.getkirby.com/sample-video.mp4)
+```
+
+<info>
+  Video will be muted automatically if `autoplay` is enabled and `muted` is not defined. To start autoplay with sound, use it as in the following example:
+
+  ```kirbytext
+  (\video: local-video.mp4 autoplay: true muted: false)
+  ```
+</info>
+
+### New Attributes
+
+The video tag now supports some attributes of the HTML `<video>` element: `autoplay`, `controls`, `loop`, `muted`, `poster`, `preload`
+
+```kirbytext
+# example 1
+(\video: local-video.mp4  autoplay: true)
+
+# example 2
+(\video: local-video.mp4 controls: false autoplay: true loop: true)
+
+# example 3
+(\video: local-video.mp4 poster: cover.jpg)
+
+# example 4
+(\video: local-video.mp4 preload: auto)
+
+# example 5
+(\video: https://www.getkirby.com/sample-video.mp4 muted: true controls: false autoplay: true)
+
+# example 6
+(\video: local-video.mp4 poster: https://www.getkirby.com/sample-cover.jpg)
+```
+
+<info>New attributes are not supported by video providers such as YouTube and Vimeo.</info>
+
+</since>
+
 ### Caption
 
 ```kirbytext

--- a/content/docs/3_reference/1_text/0_kirbytags/0_video/reference-kirbytag.txt
+++ b/content/docs/3_reference/1_text/0_kirbytags/0_video/reference-kirbytag.txt
@@ -8,7 +8,7 @@ Intro: Embeds a YouTube or Vimeo video by URL
 
 Text:
 
-## Examples and options:
+## Supported video sources
 
 ### YouTube
 
@@ -50,53 +50,28 @@ Embedded Vimeo video by video URL:
 ```
 
 <since v="3.5.5">
-### Local and remote video
+### Local and remote videos
 
-You can now embed a video on local or remote server.
+You can now embed videos from the local or from remote servers.
 
 ```kirbytext
 # local
 (\video: local-video.mp4)
 
 # remote
-(\video: https://www.getkirby.com/sample-video.mp4)
+(\video: https://example.com/sample-video.mp4)
 ```
 
 <info>
-  Video will be muted automatically if `autoplay` is enabled and `muted` is not defined. To start autoplay with sound, use it as in the following example:
-
-  ```kirbytext
-  (\video: local-video.mp4 autoplay: true muted: false)
-  ```
-</info>
-
-### New Attributes
-
-The video tag now supports some attributes of the HTML `<video>` element: `autoplay`, `controls`, `loop`, `muted`, `poster`, `preload`
+The video will be muted automatically if `autoplay` is enabled and `muted` is not defined. To start autoplay with sound, use it as in the following example:
 
 ```kirbytext
-# example 1
-(\video: local-video.mp4  autoplay: true)
-
-# example 2
-(\video: local-video.mp4 controls: false autoplay: true loop: true)
-
-# example 3
-(\video: local-video.mp4 poster: cover.jpg)
-
-# example 4
-(\video: local-video.mp4 preload: auto)
-
-# example 5
-(\video: https://www.getkirby.com/sample-video.mp4 muted: true controls: false autoplay: true)
-
-# example 6
-(\video: local-video.mp4 poster: https://www.getkirby.com/sample-cover.jpg)
+(\video: local-video.mp4 autoplay: true muted: false)
 ```
-
-<info>New attributes are not supported by video providers such as YouTube and Vimeo.</info>
-
+</info>
 </since>
+
+## Options
 
 ### Caption
 
@@ -116,6 +91,23 @@ The video tag now supports some attributes of the HTML `<video>` element: `autop
 (\video: http://youtu.be/lLuc6rtWkrM class: myvideo)
 ```
 
-### Version 2's `youtube` and `vimeo` tags
+<since v="3.5.5">
+### New attributes
+
+The video tag now supports some attributes of the HTML `<video>` element: `autoplay`, `controls`, `loop`, `muted`, `poster`, `preload`
+
+```kirbytext
+(\video: local-video.mp4 autoplay: true)
+(\video: local-video.mp4 controls: false autoplay: true loop: true)
+(\video: local-video.mp4 poster: cover.jpg)
+(\video: local-video.mp4 preload: auto)
+(\video: https://example.com/sample-video.mp4 muted: true controls: false autoplay: true)
+(\video: local-video.mp4 poster: https://example.com/sample-cover.jpg)
+```
+
+<info>These new attributes are *not* supported by video providers such as YouTube and Vimeo.</info>
+</since>
+
+## Version 2's `youtube` and `vimeo` tags
 
 <info>To keep your content compatible with older Kirby versions, we still have the old `youtube` and `vimeo` KirbyTags. We recommend switching to the new `video` tag though.</info>

--- a/content/docs/3_reference/1_text/0_kirbytags/0_video/reference-kirbytag.txt
+++ b/content/docs/3_reference/1_text/0_kirbytags/0_video/reference-kirbytag.txt
@@ -2,7 +2,7 @@ Title: video
 
 ----
 
-Intro: Embeds a YouTube or Vimeo video by URL
+Intro: Embeds a video from YouTube, Vimeo or a local file by URL or filename
 
 ----
 

--- a/content/docs/3_reference/4_objects/cms/0_responder/0_cache/reference-classmethod.txt
+++ b/content/docs/3_reference/4_objects/cms/0_responder/0_cache/reference-classmethod.txt
@@ -1,0 +1,19 @@
+Text:
+
+## Example
+
+```php
+<?php
+
+return function ($kirby, $page) {
+  $random = null;
+  if ($page->randomize()->toBool()) {
+    $random = random_int(1, 10);
+
+    // prevent Kirby from caching this response;
+    $kirby->response()->cache(false);
+  }
+
+  return compact('random');
+};
+```

--- a/content/docs/3_reference/4_objects/cms/0_responder/0_expires/reference-classmethod.txt
+++ b/content/docs/3_reference/4_objects/cms/0_responder/0_expires/reference-classmethod.txt
@@ -1,0 +1,17 @@
+Text:
+
+## Example
+
+```php
+<?php
+
+return function ($kirby) {
+  $results = yourApi();
+
+  $kirby->response()->expires(1234567890);   // timestamp OR
+  $kirby->response()->expires(60);           // minutes   OR
+  $kirby->response()->expires('2021-12-31'); // time string
+
+  return compact('results');
+};
+```

--- a/content/docs/3_reference/4_objects/cms/0_responder/reference-class.txt
+++ b/content/docs/3_reference/4_objects/cms/0_responder/reference-class.txt
@@ -1,0 +1,1 @@
+Title: $responder

--- a/content/docs/3_reference/6_system/1_options/0_fatal/reference-article.txt
+++ b/content/docs/3_reference/6_system/1_options/0_fatal/reference-article.txt
@@ -8,8 +8,12 @@ The fatal option takes a closure as value.
 
 ```php
 return [
-  'fatal' => function() {
-    include kirby()->root('templates') . '/fatal.php' ;
+  'fatal' => function($kirby, $exception) {
+    include $kirby->root('templates') . '/fatal.php';
   }
 ];
 ```
+
+<since v="3.5.5">
+The `$exception` argument was added in Kirby 3.5.5.
+</since>

--- a/content/docs/3_reference/7_plugins/1_extensions/0_panel-views/reference-extension.txt
+++ b/content/docs/3_reference/7_plugins/1_extensions/0_panel-views/reference-extension.txt
@@ -65,8 +65,35 @@ Your plugin will be available at `https://your-site.com/panel/plugins/todos`.
 |--|--|--|
 | `component` | <code></code> | Vue component definition for the view |
 | `icon` | `page` | Set icon to use in UI. Choose from (link: docs/reference/panel/icons text: these). |
-| `menu` | `true` | Whether to show custom view in Panel menu |
+| `menu` | `true` | Whether to show custom view in Panel menu, see below |
 | `label` | <code></code> | Label for menu item in Panel menu |
+
+<since v="3.5.5">
+### Dynamic control over the menu item
+
+The `menu` option can have the values `true` (always active), `false` (no menu item) or `"disabled"` (disabled menu item, e.g. if the user doesn't have enough permissions).
+
+You can also define the option as a function that receives the `app` object for dynamic control:
+
+```js "/site/plugins/todos/index.js"
+panel.plugin("yourname/todos", {
+  views: {
+    todos: {
+      label: "Todos",
+      icon: "list-bullet",
+      menu(app) {
+        if (app.$permissions["yourname.todos"].access !== true) {
+          return "disabled";
+        }
+
+        return true;
+      },
+      component: ...
+    }
+  }
+});
+```
+</since>
 
 ## CSS styles
 


### PR DESCRIPTION
✅ = Documented on the `release/3.5.5` branch

| ✅ | Issue/Feature | Related PR | Assignees | Documenting Commit |
| :-- | :--| :-- | :-- | :-- |
| ✅ | Configurable menu entry for views | https://github.com/getkirby/kirby/pull/3206 | @lukasbestle | 887b5e63104a6c930be497637387b505428d0f01 |
| ✅ | Cache (expiry) in `$kirby->response()` | https://github.com/getkirby/kirby/pull/3246 https://github.com/getkirby/kirby/pull/3292 | @lukasbestle  | 887b5e63104a6c930be497637387b505428d0f01 |
| ✅ | User language in email auth challenge | https://github.com/getkirby/kirby/pull/3294 | @lukasbestle  | 887b5e63104a6c930be497637387b505428d0f01 |
| ✅ | Pass exception to fatal error handler | https://github.com/getkirby/kirby/pull/3270 | @bastianallgeier | 887b5e63104a6c930be497637387b505428d0f01 |
| ✅ | Video kirbytag supports local and remote videos | https://github.com/getkirby/kirby/pull/3277 | @afbora | 67bcd6dccead049e405635f9958cd7192c1043c0 |