### PR TITLE
Sample code: replace pages search only

### DIFF
--- a/content/docs/3_reference/7_plugins/3_components/0_search/reference-component.txt
+++ b/content/docs/3_reference/7_plugins/3_components/0_search/reference-component.txt
@@ -12,17 +12,18 @@ Keep in mind that the search component will be used for all searches of collecti
 
 
 ```php "/site/plugins/my-search/index.php"
+<?php
+
 use Kirby\Toolkit\Collection;
 
 Kirby::plugin('my/search', [
-   'components' => [
-      'search' => function (Kirby $kirby, Collection $collection, string $query = null, $params = []) {
+  'components' => [
+    'search' => function (Kirby $kirby, Collection $collection, string $query = null, $params = []) {
+      // only search in the field named keywords
+      $result = $collection->filterBy('keywords', '*=', $query);
 
-            // only search in the field named keywords
-            $result = $collection->filterBy('keywords', '*=', $query);
-
-            return $result;
-        }
+      return $result;
+    }
   ]
 ]);
 ```
@@ -30,20 +31,24 @@ Kirby::plugin('my/search', [
 To replace the search for just one specific type of collection (e.g. for pages only), fall back on Kirby's native component for the rest:
 
 ```php "/site/plugins/my-search/index.php"
+<?php
+
+use Kirby\Toolkit\Collection;
+
 Kirby::plugin('my/search', [
-   'components' => [
-      'search' => function (Kirby $kirby, \Kirby\Toolkit\Collection $collection, string $query = null, $params = []) {
+  'components' => [
+    'search' => function (Kirby $kirby, Collection $collection, string $query = null, $params = []) {
+      // only replace the search component for Pages collections
+      if (is_a($collection, 'Kirby\Cms\Pages') === true) {
+        // only search in the field named keywords
+        $result = $collection->filterBy('keywords', '*=', $query);
 
-            // only replace the search component for Pages collections
-            if (get_class($collection) === 'Kirby\Cms\Pages') {
-                // only search in the field named keywords
-                $result = $collection->filterBy('keywords', '*=', $query);
-                return $result;
-            }
+        return $result;
+      }
 
-            // for other searches (users, files...) use the native component
-            return $kirby->nativeComponent('search')($kirby, $collection, $query, $params);
-        }
+      // use the native component for other searches (users, files...)
+      return $kirby->nativeComponent('search')($kirby, $collection, $query, $params);
+    }
   ]
 ]);
 ```

--- a/content/docs/3_reference/7_plugins/3_components/0_search/reference-component.txt
+++ b/content/docs/3_reference/7_plugins/3_components/0_search/reference-component.txt
@@ -26,3 +26,24 @@ Kirby::plugin('my/search', [
   ]
 ]);
 ```
+
+To replace the search for just one specific type of collection (e.g. for pages only), fall back on Kirby's native component for the rest:
+
+```php "/site/plugins/my-search/index.php"
+Kirby::plugin('my/search', [
+   'components' => [
+      'search' => function (Kirby $kirby, \Kirby\Toolkit\Collection $collection, string $query = null, $params = []) {
+
+            // only replace the search component for Pages collections
+            if (get_class($collection) === 'Kirby\Cms\Pages') {
+                // only search in the field named keywords
+                $result = $collection->filterBy('keywords', '*=', $query);
+                return $result;
+            }
+
+            // for other searches (users, files...) use the native component
+            return $kirby->nativeComponent('search')($kirby, $collection, $query, $params);
+        }
+  ]
+]);
+```


### PR DESCRIPTION
As replacing `->search()` globally has a wide impact, the more likely use case for most developers might be to only customize the search for a specific collection type?

Probably obvious for experienced PHP developers, this example gives a copy-paste solution for only replacing one of them and fall back on the built-in defaults for the rest.

Feel free to edit or discard :)