### PR TITLE
Update email form cookbook recipe with the URL type for the honeypot field

### DIFF
--- a/content/docs/2_cookbook/4_forms/0_basic-contact-form/cookbook-recipe.txt
+++ b/content/docs/2_cookbook/4_forms/0_basic-contact-form/cookbook-recipe.txt
@@ -40,7 +40,7 @@ Our `contact.php` template contains the form and will display error messages if 
         <form method="post" action="<?= $page->url() ?>">
             <div class="honeypot">
                 <label for="website">Website <abbr title="required">*</abbr></label>
-                <input type="website" id="website" name="website" tabindex="-1">
+                <input type="url" id="website" name="website" tabindex="-1">
             </div>
             <div class="field">
                 <label for="name">


### PR DESCRIPTION
The honeypot field in the cookbook recipe for an email form showed a website field using input type "website"
which doesn't exist in this form in the HTML specification. Presumly, what was meant is a field with the type "url", except the non-existing "website" type is some form of black magic tricking spambots into filling the field which I don't know of and that isn't explained in the example.

The type used in the example is now "url".