### PR TITLE
Update description for File::setParent()

### DIFF
--- a/kirby/src/Cms/File.php
+++ b/kirby/src/Cms/File.php
@@ -688,7 +688,9 @@ class File extends ModelWithContent
     }
 
     /**
-     * Sets the parent model object
+     * Sets the parent model object;
+     * this property is required for `File::create()` and
+     * will be generally required starting with Kirby 3.7.0
      *
      * @param \Kirby\Cms\Model|null $parent
      * @return $this


### PR DESCRIPTION
Fixes #1348.

Generally we don't update the `kirby` dir in getkirby.com manually, but I think here it makes sense to already document this now and not wait for the 3.6.0 release. I have also pushed the change to the PR branch for https://github.com/getkirby/kirby/pull/3372.