### PR TITLE
Remove redundant line from submodule example

### DIFF
--- a/content/docs/2_cookbook/9_setup/0_git/cookbook-recipe.txt
+++ b/content/docs/2_cookbook/9_setup/0_git/cookbook-recipe.txt
@@ -50,7 +50,6 @@ cd your-project
 
 # remove the kirby directory as it will be replaced in the next step
 rm -R kirby
-git add kirby
 
 # install the submodule
 git submodule add https://github.com/getkirby/kirby.git kirby


### PR DESCRIPTION
`git add kirby` causes an error in this example. The command is not needed is not needed to successfully achieve the recipe.