### PR TITLE
Kirby 3.6 release page / fiber: correct dialog definition syntax

### DIFF
--- a/content/releases/3-6/1_features/1_fiber/release-guide.txt
+++ b/content/releases/3-6/1_features/1_fiber/release-guide.txt
@@ -213,7 +213,7 @@ Kirby::plugin('yourname/todos', [
         'dialogs' => [
 
           // the key of the dialog defines the dialog routing pattern
-          'todos/create' => function () {
+          'todos/create' => [
             // the load event is creating a GET route at
             // `/panel/dialogs/{pattern}`;
             // it returns the setup for the dialog, including
@@ -238,7 +238,7 @@ Kirby::plugin('yourname/todos', [
               // create todo
               return true;
             }
-          }
+          ]
         ]
       ]
     };


### PR DESCRIPTION
dialog definition should either be an array or (I guess) a function returning an array. Currently it's a function with the body of an array.