### PR TITLE
allow explicit download links for plugins

### DIFF
--- a/site/models/plugin.php
+++ b/site/models/plugin.php
@@ -20,6 +20,10 @@ class PluginPage extends Page
 
     public function download()
     {
+        if ($this->content()->has('download')) {
+            return $this->content()->get('download')->value();
+        }
+
         $url   = $this->repository()->value();
         $branch = $this->branch()->value() ?? 'master';
 


### PR DESCRIPTION
For plugins that have a build step and don't include the build artifacts in the source repo, it's useful to be able to explicitly set the download link to an URL that contains the build. 

This PR enables plugins to manually define the Download link in the plugin.txt datafile:

Example:
```yaml
----

Repository: https://github.com/rasteiner/k3-query-field

----

Download: https://api.github.com/repos/rasteiner-dist/k3-query-field/zipball

----
```

When no `Download` field is specified, the model falls back to the current behavior of deducing it from the `Repository`.