### PR TITLE
fix: add example for kirbytag attribute

### DIFF
--- a/content/docs/3_reference/7_plugins/1_extensions/0_kirbytags/reference-extension.txt
+++ b/content/docs/3_reference/7_plugins/1_extensions/0_kirbytags/reference-extension.txt
@@ -76,7 +76,7 @@ Kirby::plugin('your/plugin', [
 
 ## Adding attributes
 
-If you want to add attributes, you can add them as an `attr` array like this:
+If you want to add attributes (e.g. `(wikipedia: class: my-class)`), you can add them as an `attr` array like this:
 
 ```php
 <?php


### PR DESCRIPTION
- Add an example for a kirbytag with an attribute