### PR TITLE
nest level of the tailwind.css in the src folder

### DIFF
--- a/content/docs/2_cookbook/9_setup/0_kirby-meets-tailwindcss/cookbook-recipe.txt
+++ b/content/docs/2_cookbook/9_setup/0_kirby-meets-tailwindcss/cookbook-recipe.txt
@@ -44,7 +44,8 @@ Also in the projects's root, we create a `package.json` file which controls the 
 {
     "name": "projectname",
 	"scripts": {
-		"watch": "npx tailwindcss -i ./src/css/tailwind.css -o ./assets/css/styles.css --jit --purge './site/**/*.php' -w",
+		"watch": "npx tailwindcss -i ./src/css/
+		-o ./assets/css/styles.css --jit --purge './site/**/*.php' -w",
         "build": "npx tailwindcss -i ./src/css/tailwind.css -o ./assets/css/styles.css --jit --purge './site/**/*.php' -m"
 	}
 }
@@ -77,7 +78,7 @@ Our `/src` folder should look like follows and we are ready to install Tailwind 
 ```filesystem
 src/
   css/
-  tailwind.css
+    tailwind.css
 ```
 
 


### PR DESCRIPTION
Currently, the folder structure figure shows that `tailwind.css` is placed alongside the `css` folder, while it says "we create a subfolder `/css` in the `/src` folder and inside that folder a file called `tailwind.css`.".