### PR TITLE
Update loops cookbook recipe

### DIFF
--- a/content/docs/2_cookbook/3_templating/0_loops/cookbook-recipe.txt
+++ b/content/docs/2_cookbook/3_templating/0_loops/cookbook-recipe.txt
@@ -159,7 +159,7 @@ You can also fetch a particular item by its position in the collection, using th
 
 ```php
 $items  = $pages->listed();
-$item = $items->nth(3); // get the third element in the collection
+$item = $items->nth(3); // get the 4th element in the collection (index starts at 0)
 echo $item->title();
 ```
 


### PR DESCRIPTION
Minor correction: The index of nth() starts at zero, so the selected element in the example is actually the fourth.