### PR TITLE
Add note: pages() for published pages only

### DIFF
--- a/content/docs/3_reference/2_templates/0_helpers/0_pages/reference-helper.txt
+++ b/content/docs/3_reference/2_templates/0_helpers/0_pages/reference-helper.txt
@@ -6,3 +6,6 @@ Text:
 <?php $collection = pages(['home', 'blog']) ?>
 <?php $collection = pages([$page, $page->children()->first()]) ?>
 ```
+<info>
+The `pages()` helper fetches published pages only; ids of draft pages are ignored.
+</info>


### PR DESCRIPTION
This took me a while to figure out; maybe helpful for others?

I did propose a solution at https://forum.getkirby.com/t/how-to-create-a-pages-collection-from-ids-of-draft-pages/20580/2 but am not sure whether/how to add it to this doc as well?