### PR TITLE
single quotes to double in query language example

### DIFF
--- a/content/docs/1_guide/6_blueprints/4_query-language/guide.txt
+++ b/content/docs/1_guide/6_blueprints/4_query-language/guide.txt
@@ -37,9 +37,9 @@ $page->images()->template('image')
 site.title
 page.title.lower
 page.children
-page.children.filterBy('featured', true)
-site.find('notes').children.filterBy('tags', 'ocean', ',')
-page.images.template('image')
+page.children.filterBy("featured", true)
+site.find("notes").children.filterBy("tags", "ocean", ",")
+page.images.template("image")
 ```
 
 These are just a few examples. As you can see, it is very close to the PHP syntax. You don't need to relearn anything this way.


### PR DESCRIPTION
Changed single quotes to double in query language example, per note above recommending double quotes to prevent Panel errors.