### PR TITLE
Replace Parcel with kirbyup

### DIFF
--- a/content/docs/1_guide/17_plugins/6_plugin-setup-panel/guide.txt
+++ b/content/docs/1_guide/17_plugins/6_plugin-setup-panel/guide.txt
@@ -14,37 +14,27 @@ Our Pluginkit for Panel plugins is almost identical to the basic setup – excep
 
 ## Installation
 
-We have created a simple example plugin called the Pluginkit.
-You can find the code for this tutorial in the (link: https://github.com/getkirby/pluginkit/tree/4-panel text: `4-panel`) branch.
+We have created a simple example plugin called the Pluginkit. You can find the code for this tutorial in the (link: https://github.com/getkirby/pluginkit/tree/4-panel text: `4-panel`) branch.
 
 If you want to follow along, you can download a (link: https://github.com/getkirby/pluginkit/archive/4-panel.zip text: **ZIP file**) of that branch or get it via Composer:
 
 ```
 composer create-project getkirby/pluginkit site/plugins/your-plugin dev-4-panel --remove-vcs
 ```
+
 <info>
 Note: Composer is not required to follow this tutorial.
 </info>
 
-## Introducing Parcel
+## Introducing kirbyup
 
-For our build and dev process, we use a bundler called (link: https://parceljs.org/ text: Parcel). Parcel is basically doing the same thing as tools like Webpack or Rollup, but with less moving parts to know and worry about. It will help to compile Vue's single file components, convert SASS in your style blocks, minify your code when you build your plugin and more.
+For our development and production process, we use a bundler called (link: https://github.com/johannschopplich/kirbyup text: kirbyup). It is tailored for Kirby Panel plugins, utilizing [Vite](https://vitejs.dev) under the hood, and works right of the box. It will help to compile Vue's single file components, convert SASS in your style blocks, minify your code when you build your plugin and more.
 
-We recommend to install Parcel globally. That way you can reuse it to work on multiple plugins.
-
-```
-npm install -g parcel-bundler
-```
-
-You can also use Yarn instead:
-
-```
-yarn global add parcel-bundler
-```
+You don't even have to install kirbyup. When running your first npm command, kirbyup will be remotely fetched and available for all subsequent commands. The initial package fetching might take a moment.
 
 ## Development process
 
-Once Parcel is installed on your machine, you can start the development process in your plugin directory with …
+You can start the development process in your plugin directory with:
 
 ```
 npm run dev
@@ -56,13 +46,13 @@ This will automatically create your plugin's `index.js` and `index.css` and keep
 
 Your Panel plugin code is located in the `src` folder. Your main plugin file is `src/index.js`. In that file you can import Vue components and define all your different plugin types. In our example setup, we've created a simple custom view that will appear in the Panel's main menu. But you can use this for fields, sections or any other type of Panel plugin of course.
 
-### Hot module reloading
+### Panel reloading
 
-Parcel has a nice built-in feature called hot module reloading. This means that the Panel will automatically apply changes whenever you work on your plugin code without you having to reload the browser. This should be working out of the box as soon as you loaded the plugin for the first time.
+To inspect changes made by your plugin, you will have to trigger a manual reload in your Panel. kirbyup doesn't support hot module reloading yet, wants to in the future.
 
 ## Building your plugin
 
-Once you are happy with your plugin, you can create minified and optimized versions of the `index.js` and `index.css` with …
+Once you are happy with your plugin, you can create minified and optimized versions of the `index.js` and `index.css` with:
 
 ```
 npm run build

--- a/content/docs/1_guide/17_plugins/6_plugin-setup-panel/guide.txt
+++ b/content/docs/1_guide/17_plugins/6_plugin-setup-panel/guide.txt
@@ -48,7 +48,7 @@ Your Panel plugin code is located in the `src` folder. Your main plugin file is 
 
 ### Panel reloading
 
-To inspect changes made by your plugin, you will have to trigger a manual reload in your Panel. kirbyup doesn't support hot module reloading yet, wants to in the future.
+Reload the Kirby Panel after you have updated the plugin's code to inspect your changes.
 
 ## Building your plugin
 

--- a/content/docs/2_cookbook/10_panel/0_custom-block-type/cookbook-recipe.txt
+++ b/content/docs/2_cookbook/10_panel/0_custom-block-type/cookbook-recipe.txt
@@ -31,7 +31,7 @@ Kirby's (link: docs/reference/panel/fields/blocks text: blocks field) comes with
 - A Kirby (link: docs/guide/quickstart#download-and-installation text: Plainkit or Starterkit) for testing
 - A code editor
 - Basic understanding (link: docs/guide/plugins/plugin-basics text: how to create plugins in Kirby)
-- For the single file approach, (link: https://parceljs.org/ text: Parcel)  must be installed on your system, unless you use your own custom build process. But don't worry, we also show you how to build this block without such a build process (see link below).
+- For the single file approach, Node 14+ and (link: https://github.com/johannschopplich/kirbyup text: kirbyup). But don't worry, we also show you how to build this block without such a build process (see link below).
 - Probably a big pot of hot coffee and a cool head. We are going to dive deep.
 
 ## Resources
@@ -397,21 +397,15 @@ We also need a `package.json` next to `index.php` with the following content:
 ```js "/site/plugins/audio-block/package.json"
 {
   "scripts": {
-    "dev": "parcel watch src/index.js --no-source-maps -d ./",
-    "build": "parcel build src/index.js --no-source-maps --experimental-scope-hoisting -d ./"
-  },
-  "posthtml": {
-    "recognizeSelfClosing": true
+    "dev": "npx -y kirbyup src/index.js --watch",
+    "build": "npx -y kirbyup src/index.js"
   }
 }
 ```
-This file tells the (link: https://parceljs.org/ text: Parcel) bundler which files to compile and an output destination. Since our plugin setup is always the same in our documentation, it's the same file we also use in our other Panel related plugin recipes.
 
-If you haven't installed Parcel globally yet, you can do this by running the following command:
+This file tells the (link: https://github.com/johannschopplich/kirbyup text: kirbyup) bundler which files to compile. Since our plugin setup is always the same in our documentation, it's the same file we also use in our other Panel related plugin recipes.
 
-```
-npm install -g parcel-bundler
-```
+You don't have to install kirbyup locally or globally, since it will be fetched remotely once when running your first command. This may take a short amount of time.
 
 The `package.json` file has two script commands, `dev` and `build`. The `dev` command runs a watcher that compiles the source files whenever we are making changes, the `build` command builds our production-ready file.
 

--- a/content/docs/2_cookbook/10_panel/0_to-bundle-or-not-to-bundle/cookbook-recipe.txt
+++ b/content/docs/2_cookbook/10_panel/0_to-bundle-or-not-to-bundle/cookbook-recipe.txt
@@ -455,7 +455,7 @@ Published: 2021-03-05
 
 ----
 
-Description: Using bundlers like Parcel is not for everyone. Here we show how you can build Panel extensions without a build process.
+Description: Using bundlers like kirbyup is not for everyone. Here we show how you can build Panel extensions without a build process.
 
 ----
 

--- a/content/docs/2_cookbook/7_extensions/0_first-panel-field/cookbook-recipe.txt
+++ b/content/docs/2_cookbook/7_extensions/0_first-panel-field/cookbook-recipe.txt
@@ -16,7 +16,7 @@ This cookbook recipe is based on these two video episodes…
 In this recipe, we start with the basics of creating a field from scratch using a Vue.js single file component, and then build on this by reusing parts of Kirby's UI Kit. We will deviate a little from the example in the videos though, and our final result will be a text input for (link: https://www.doi.org/ text: DOI names), with a link that allows us to verify the input by calling the link `https://www.doi.org/` suffixed with the field input.
 
 <info>
-For the purposes of this recipe, we assume that Parcel is already installed globally as described in the (link: docs/guide/plugins/plugin-setup-panel text: Panel plugin setup guide).
+For the purposes of this recipe, we assume you have read the (link: docs/guide/plugins/plugin-setup-panel text: Panel plugin setup guide) on how to get started with our Panel plugin bundler (link: https://github.com/johannschopplich/kirbyup text: kirbyup).
 
 You can install the (link: https://github.com/getkirby/pluginkit/tree/4-panel text: Pluginkit) as a basis or create the file structure we need manually, that's up to you. Also, it doesn't matter if you use the Plainkit or the Starterkit as a starting point.
 </info>
@@ -26,16 +26,13 @@ Let's start by creating a new folder in the `plugins` folder called `doifield`. 
 ```js "/site/plugins/moviereviews/package.json"
 {
   "scripts": {
-    "dev": "parcel watch src/index.js --no-source-maps -d ./",
-    "build": "parcel build src/index.js --no-source-maps --experimental-scope-hoisting -d ./"
-  },
-  "posthtml": {
-    "recognizeSelfClosing": true
+    "dev": "npx -y kirbyup src/index.js --watch",
+    "build": "npx -y kirbyup src/index.js"
   }
 }
 ```
-This will take care of compiling our source files into an `index.js` file in the root of our `doifield` plugin folder.
 
+This will take care of compiling our source files into an `index.js` file in the root of our `doifield` plugin folder.
 
 ## Register the field: PHP part
 
@@ -91,7 +88,6 @@ npm run dev
 ```
 
 …in the `/doifield` folder to compile the code. If everything works as expected, there will now be a compiled `index.js` file in the `doifield` folder.
-
 
 ## Blueprint
 

--- a/content/docs/2_cookbook/7_extensions/0_first-panel-field/cookbook-recipe.txt
+++ b/content/docs/2_cookbook/7_extensions/0_first-panel-field/cookbook-recipe.txt
@@ -159,8 +159,8 @@ panel.plugin('pluginAuthor/doi', {
 In the Panel, we won't see any changes at this point.
 
 ## Creating an HTML field input
-Let's move a little further and turn this into a real field input using a standard HTML input tag:
 
+Let's move a little further and turn this into a real field input using a standard HTML input tag:
 
 ```html "site/plugins/doifield/src/components/fields/DoiField.vue"
 <template>
@@ -206,11 +206,6 @@ Once we reload the page in the Panel, we see that the label has changed:
 
 (image: doifield-3.jpg)
 
-
-<info>
-Note that hot module reloading only works for frontend code, when changing stuff in the background, you need to reload the page.
-</info>
-
 ## Load value of field into Panel
 
 Currently, our input field has no content yet. Before we start editing the field in the Panel, let's add some content in our text file and see how we can load the value of the field into the input field.
@@ -222,7 +217,6 @@ Title: Sandbox
 
 Doi: Some boring text
 ```
-
 
 Let's add `value` as a prop and bind this value to the input field with `:value="value"`. 
 
@@ -251,7 +245,6 @@ export default {
 (image: doifield-4.jpg)
 
 Great, we can now bind the value in the text field to the input. But if we try to change the value in the Panel, nothing will happen yet, no orange save bar will pop up, and we cannot store changes.
-
 
 ## Events
 

--- a/content/docs/2_cookbook/7_extensions/0_first-panel-section/cookbook-recipe.txt
+++ b/content/docs/2_cookbook/7_extensions/0_first-panel-section/cookbook-recipe.txt
@@ -8,9 +8,8 @@ In this recipe, we will create a custom Panel section that displays a list of li
 
 (image: custom-section.jpg)
 
-
 <info>
-For the purposes of this recipe, we assume that Parcel is already installed globally as described in the (link: docs/guide/plugins/plugin-setup-panel text: Panel plugin setup guide).
+For the purposes of this recipe, we assume you have read the (link: docs/guide/plugins/plugin-setup-panel text: Panel plugin setup guide) on how to get started with our Panel plugin bundler (link: https://github.com/johannschopplich/kirbyup text: kirbyup).
 
 You can install the (link: https://github.com/getkirby/pluginkit/tree/4-panel text: Pluginkit) as a basis or create the file structure we need manually, that's up to you. Also, it doesn't matter if you use the Plainkit or the Starterkit as a starting point.
 </info>
@@ -19,19 +18,17 @@ You can install the (link: https://github.com/getkirby/pluginkit/tree/4-panel te
 
 Please read the (link: docs/reference/plugins/extensions/sections text: chapter about custom sections in the reference) before starting with this example.
 
-Let's get started with the plugin folder, we'll call it `/linksection`. Inside this folder, we create a `package.json` file which is needed so that Parcel knows what to do.
+Let's get started with the plugin folder, we'll call it `/linksection`. Inside this folder, we create a `package.json` file which is needed so that kirbyup knows what to do.
 
 ```yaml "/site/plugins/linksection/package.json"
 {
   "scripts": {
-    "dev": "parcel watch src/index.js --no-source-maps -d ./",
-    "build": "parcel build src/index.js --no-source-maps --experimental-scope-hoisting -d ./"
-  },
-  "posthtml": {
-    "recognizeSelfClosing": true
+    "dev": "npx -y kirbyup src/index.js --watch",
+    "build": "npx -y kirbyup src/index.js"
   }
 }
 ```
+
 This will take care of compiling our source files into an `index.js` file in the root of our `linksection` plugin folder.
 
 ## Register the section: PHP part

--- a/content/docs/2_cookbook/7_extensions/0_first-panel-view/cookbook-recipe.txt
+++ b/content/docs/2_cookbook/7_extensions/0_first-panel-view/cookbook-recipe.txt
@@ -9,7 +9,7 @@ For our very first Panel view, we will query a public API and display the result
 (image: movie-reviews-custom-view.jpg)
 
 <info>
-For the purposes of this recipe, we assume that Parcel is already installed globally as described in the (link: docs/guide/plugins/plugin-setup-panel text: Panel plugin setup guide).
+For the purposes of this recipe, we assume you have read the (link: docs/guide/plugins/plugin-setup-panel text: Panel plugin setup guide) on how to get started with our Panel plugin bundler (link: https://github.com/johannschopplich/kirbyup text: kirbyup).
 
 You can install the (link: https://github.com/getkirby/pluginkit/tree/4-panel text: Pluginkit) as a basis or create the file structure we need manually, that's up to you. Also, it doesn't matter if you use the Plainkit or the Starterkit as a starting point.
 </info>
@@ -19,16 +19,13 @@ Let's start by creating a new folder in the plugins folder, which we will call `
 ```js "/site/plugins/moviereviews/package.json"
 {
   "scripts": {
-    "dev": "parcel watch src/index.js --no-source-maps -d ./",
-    "build": "parcel build src/index.js --no-source-maps --experimental-scope-hoisting -d ./"
-  },
-  "posthtml": {
-    "recognizeSelfClosing": true
+    "dev": "npx -y kirbyup src/index.js --watch",
+    "build": "npx -y kirbyup src/index.js"
   }
 }
 ```
-This will take care of compiling our source files into an `index.js` file in the root of our `moviereviews` plugin folder.
 
+This will take care of compiling our source files into an `index.js` file in the root of our `moviereviews` plugin folder.
 
 ## Custom API route
 
@@ -126,7 +123,7 @@ Now let's run
 npm run dev
 ```
 
-in our plugin folder, and Parcel will compile an `index.js` in the `moviereviews` folder.
+in our plugin folder, and kirbyup will compile an `index.js` in the `moviereviews` folder.
 
 If all went well, we will now see a new menu entry in the Panel dropdown navigation, and when we click on it, we can visit the newly created view that's still empty at this time.
 

--- a/content/docs/2_cookbook/9_setup/0_monolithic-plugin-setup/cookbook-recipe.txt
+++ b/content/docs/2_cookbook/9_setup/0_monolithic-plugin-setup/cookbook-recipe.txt
@@ -32,27 +32,20 @@ Kirby::plugin('getkirby/pluginkit', [
 ]);
 ```
 
-...and `package.json` with npm scripts for [Parcel](https://parceljs.org/):
+...and `package.json` with npm scripts for [kirbyup](https://github.com/johannschopplich/kirbyup):
 
 ```js
 {
   "scripts": {
-    "dev": "parcel watch src/index.js --no-source-maps -d ./",
-    "build": "parcel build src/index.js --no-source-maps --experimental-scope-hoisting -d ./"
-  },
-  "posthtml": {
-    "recognizeSelfClosing": true
+    "dev": "npx -y kirbyup src/index.js --watch",
+    "build": "npx -y kirbyup src/index.js"
   }
 }
 ```
 
-If you don't have Parcel, install it globally on your machine:
+You don't have to install kirbyup locally or globally, since it will be fetched remotely once when running your first command. This may take a short amount of time.
 
-```bash
-npm install -g parcel
-```
-
-After that, you should be able to start it up by running the `dev` npm script:
+Now, start kirbyup in watch mode by running the `dev` npm script:
 
 ```bash
 npm run dev


### PR DESCRIPTION
It's finally here! Parcel v1 can now rest in peace in favor of [kirbyup](https://github.com/johannschopplich/kirbyup). I have changed all occurrences (excluding Kirby Kosmos issues) and usage instructions.

We can even drop the global (or otherwise local) install instructions, since we simply use `npx` to run kirybup. Thus, no `devDependencies` inside the `package.json`. It will be cached globally and reusable for other Panel plugins, but the user won't have to do a thing. From:

```json
{
  "scripts": {
    "dev": "parcel watch src/index.js --no-source-maps -d ./",
    "build": "parcel build src/index.js --no-source-maps --experimental-scope-hoisting -d ./"
  },
  "posthtml": {
    "recognizeSelfClosing": true
  }
}
```

To:

```json
{
  "scripts": {
    "dev": "npx -y kirbyup src/index.js --watch",
    "build": "npx -y kirbyup src/index.js"
  }
}
```

Thus, no need to run either `npm i`, nor `npm i -g kirbyup`!

I hope the changes appeal to you. Feedback welcome. And: Happy 3.6 beta release! What do you think about mentioning kirbyup in the release changelog? Some developers may want to switch.

Related: https://github.com/getkirby/getkirby.com/issues/1434