### PR TITLE
Add template: to pages section options

### DIFF
--- a/content/docs/3_reference/3_panel/4_sections/0_pages/reference-panelsection.txt
+++ b/content/docs/3_reference/3_panel/4_sections/0_pages/reference-panelsection.txt
@@ -71,7 +71,7 @@ Keep in mind that the same section name can only be used once per blueprint.
 
 The pages section has multiple options to control what kind of pages should be displayed, how they should be displayed and what happens if a new page is added.
 
-(section-options: pages)
+(section-options: pages) 
 
 ## Headline
 


### PR DESCRIPTION
(section-options: pages)
In this list I want to change 'templates' into 'template: or templates: '.
I had been searching a long time to find this, and I couldn't find "option template:" anywhere. Until I followed the link to panel/sections/pages  _and_ scrolled down beyond the options list.    
(I know I can't change the options myself, I believe they are generated somehow)