### PR TITLE
Add `email` to the available writer marks

### DIFF
--- a/content/docs/3_reference/3_panel/3_fields/0_writer/reference-article.txt
+++ b/content/docs/3_reference/3_panel/3_fields/0_writer/reference-article.txt
@@ -54,6 +54,7 @@ The writer field supports the following marks by default:
 - `strike`
 - `code`
 - `link`
+- `email`
 
 ```yaml
 fields:

--- a/kirby/config/fields/writer.php
+++ b/kirby/config/fields/writer.php
@@ -11,7 +11,7 @@ return [
             return $inline;
         },
         /**
-         * Sets the allowed HTML formats. Available formats: `bold`, `italic`, `underline`, `strike`, `code`, `link`. Activate them all by passing `true`. Deactivate them all by passing `false`
+         * Sets the allowed HTML formats. Available formats: `bold`, `italic`, `underline`, `strike`, `code`, `link`, `email`. Activate them all by passing `true`. Deactivate them all by passing `false`
          * @param array|bool $marks
          */
         'marks' => function ($marks = true) {


### PR DESCRIPTION
Small doc improvement... Added `email` as a available format to the writer marks.