### PR TITLE
Update Kirby Annotator plugin to its current name

### DIFF
--- a/content/plugins/sylvainjule/annotator/plugin.txt
+++ b/content/plugins/sylvainjule/annotator/plugin.txt
@@ -2,7 +2,7 @@ Title: Annotator
 
 ----
 
-Repository: https://github.com/sylvainjule/kirby-image-annotator
+Repository: https://github.com/sylvainjule/kirby-annotator
 
 ----
 


### PR DESCRIPTION
The Kirby Annotator plugin seems to have been renamed from Kirby Image Annotator to its current name Kirby Annotator. This edit makes sure the correct URL is used for the `plugins.json` route and others.