### PR TITLE
Remove trailing slash from repository link.

### DIFF
--- a/content/plugins/gearsdigital/reporter/plugin.txt
+++ b/content/plugins/gearsdigital/reporter/plugin.txt
@@ -2,7 +2,7 @@ Title: Reporter
 
 ----
 
-Repository: https://github.com/gearsdigital/kirby-reporter/
+Repository: https://github.com/gearsdigital/kirby-reporter
 
 ----
 


### PR DESCRIPTION
For consistency in the usage of the Plugins API.
This is the only plugin that had a trailing slash, that should be removed for consistency reasons.