### PR TITLE
Enhancements to release page

### DIFF
--- a/content/releases/3-6/fiber/release-guide.txt
+++ b/content/releases/3-6/fiber/release-guide.txt
@@ -55,19 +55,19 @@ When you now click on a link in the Panel, the event is intercepted and a JS fet
 ```
 Fiber now does two things:
 
-1. It updates the URL in the browser
-2. It refreshes the Vue app with the new state from the new Fiber object
+1. It updates the URL in the browser.
+2. It refreshes the Vue app with the new state from the new Fiber object.
 
 Whenever you reload the same URL afterwards, you go back to the beginning and the server will return the full document again with the same state.
 
 ### What makes this approach so great?
 
-- Routing is done in PHP with our good old Kirby router.
-- We can exactly control what data needs to be sent for each view.
+- Routing is done in PHP with our trusted Kirby router.
+- We can control what exact data needs to be sent for each view.
 - State can be handled on the server with good old sessions.
 - The API is not affected by any of this and can be a lot less specific.
 - The bundle size does not blow up with new routes or new requirements for state management.
-- Less logic in JS and a lot less complicated Vue components. You throw in state via props and that's it.
+- Less logic is needed in JS, which results in a lot less complicated Vue components. You throw in state via props and that's it.
 - Every view is super easy to test on the backend with PHPUnit.
 
 ### Not just views
@@ -80,4 +80,4 @@ With this approach, we already managed to (link: /releases/3.6#fiber text: cut a
 
 ### Why not just Inertia.js?
 
-Fiber is mainly inspired by (link: https://inertiajs.com/ text: Inertia.js). But the more we dug into the concept, the more ways we found how we can adjust and improve the principles of Inertia for our own needs. First, we implemented our own client implementation of Inertia. Then we started changing lots of parts on the backend. In the end, the basic request concept is still the same, but the implementation is very different. It felt confusing to use the same name. You cannot lookup things in the Inertia.js docs when you work with the Panel. Dialogs and other ideas for future Fiber Panel features don't exist in Inertia. Fiber seemed like an appropriate alternative term.
+Fiber is mainly inspired by (link: https://inertiajs.com/ text: Inertia.js). But the more we dug into the concept, the more ways we found how we can adjust and improve the principles of Inertia for our own needs. First, we implemented our own client implementation of Inertia. Then we started changing lots of parts on the backend. In the end, the basic request concept is still the same, but the implementation is very different. It felt confusing to use the same name. You cannot look up things in the Inertia.js docs when you work with the Panel. Dialogs and other ideas for future Fiber Panel features don't exist in Inertia. Fiber seemed like an appropriate alternative term.

--- a/site/snippets/templates/release-36/blocks.php
+++ b/site/snippets/templates/release-36/blocks.php
@@ -2,7 +2,7 @@
   'id'       => 'blocks',
   'title'    => 'Blocks',
   'intro'    => 'Now even more awesome',
-  'text'     => 'Our blocks field has lifted Kirby’s editing experience to another level since 3.5. Now we are taking it even a step further.',
+  'text'     => 'The blocks field we introduced in Kirby 3.5 has lifted Kirby’s editing experience to another level. Now we are even taking it a step further.',
   'figure'   => 'templates/release-36/blocks-figure',
   'features' => [
     [
@@ -15,7 +15,7 @@
     ],
     [
       'title' => 'New line block',
-      'text' => 'The new line block supports and automatically imports <code>hr</code> blocks from the old Editor plugin and <code>hr</code> elements from pasted HTML'
+      'text' => 'The new line block supports and automatically imports <code>hr</code> blocks from the old Editor plugin and <code>hr</code> elements from pasted HTML.'
     ],
     [
       'title' => 'Privacy friendly video block',

--- a/site/snippets/templates/release-36/cardlets.php
+++ b/site/snippets/templates/release-36/cardlets.php
@@ -2,7 +2,7 @@
   <?php snippet('templates/features/intro', [
     'title' => 'Cardlets',
     'intro' => 'A new way to present your content',
-    'text'  => 'While lists are great for dense information and cards are fantastic if you want to highlight visual content, there’s often a gray zone in between. The new cardlets layout option gives you nice visual previews while your text content is still representend decently. Use them in pages or files sections as well as pages, files or users fields.'
+    'text'  => 'While lists are great for dense information and cards are fantastic to highlight visual content, there’s often a gray zone in between. The new cardlets layout option gives you nice visual previews while your text content is still represented decently. Use them in pages and files sections as well as pages, files and users fields.'
   ]) ?>
 
   <div class="columns mb-6" style="--columns: 3; --gap: var(--spacing-1)">

--- a/site/snippets/templates/release-36/image-formats-figure.php
+++ b/site/snippets/templates/release-36/image-formats-figure.php
@@ -2,13 +2,13 @@
   <figure>
     <img src="<?= ($image = $page->image('demo.jpg'))->url() ?>" loading="lazy">
     <figcaption class="font-mono text-sm pt-1">
-      JPG <?= $image->niceSize() ?>
+      JPEG <?= $image->niceSize() ?>
     </figcaption>
   </figure>
   <figure>
     <img src="<?= ($image = $page->image('demo.webp'))->url() ?>" loading="lazy">
     <figcaption class="font-mono text-sm pt-1">
-      Webp <?= $image->niceSize() ?>
+      WebP <?= $image->niceSize() ?>
     </figcaption>
   </figure>
   <figure>

--- a/site/snippets/templates/release-36/image-formats.php
+++ b/site/snippets/templates/release-36/image-formats.php
@@ -2,6 +2,6 @@
   'id'    => 'image-formats',
   'title' => 'WebP & AVIF Support',
   'intro' => 'Serve smaller and better images',
-  'text'  => 'With increasingly better browser support for WebP and AVIF on the horizon, optimizing images becomes a lot easier. <br><br> The performance benefits are obvious. WebP can produce high quality images with roughly 50% smaller files compared to JPEG and AVIF can go even lower than that.<br><br>Our image processing engine now supports both formats, and with the help of the picture element you can even make older browsers happy. <a href="/docs/guide/templates/resize-images-on-the-fly#image-formats">Learn more &rsaquo;</a></p>',
+  'text'  => 'With increasingly better browser support for WebP and AVIF on the horizon, optimizing images has become a lot easier. <br><br> The performance benefits are obvious. WebP can produce high quality images with roughly 50% smaller files compared to JPEG and AVIF can go even lower than that.<br><br>Our image processing engine now supports both formats, and with the help of the <code>&lt;picture&gt;</code> element you can even make older browsers happy. <a href="/docs/guide/templates/resize-images-on-the-fly#image-formats">Learn more &rsaquo;</a></p>',
   'figure' => 'templates/release-36/image-formats-figure',
 ]);

--- a/site/snippets/templates/release-36/plugins.php
+++ b/site/snippets/templates/release-36/plugins.php
@@ -20,7 +20,7 @@
     ],
     [
       'title' => 'No more API endpoint hassle',
-      'text' => 'With Fiber, you return exactly the data you need for your Panel components. Good-bye to multiple API calls or custom API routes. Write some PHP and be done.'
+      'text' => 'With Fiber, you return exactly the data you need for your Panel components. Goodbye to multiple API calls or custom API routes. Write some PHP and be done.'
     ],
   ]
 ]);

--- a/site/snippets/templates/release-36/stats.php
+++ b/site/snippets/templates/release-36/stats.php
@@ -22,7 +22,7 @@
       ] as $contributor): ?>
       <li class="inline-flex p-1">
         <a href="https://github.com/<?= $contributor ?>" class="p-3 text-sm font-mono shadow bg-white rounded flex items-center">
-          <img src="https://github.com/<?= $contributor ?>.png?size=32" style="border-radius: 100%; width: auto" class="mr-3" width="32" height="32" loading="lazy"> @<?= $contributor ?>
+          <img src="https://github.com/<?= $contributor ?>.png?size=64" style="border-radius: 100%; width: auto" class="mr-3" width="32" height="32" loading="lazy"> @<?= $contributor ?>
         </a>
       </li>
       <?php endforeach ?>

--- a/site/snippets/templates/release-36/stats.php
+++ b/site/snippets/templates/release-36/stats.php
@@ -22,7 +22,7 @@
       ] as $contributor): ?>
       <li class="inline-flex p-1">
         <a href="https://github.com/<?= $contributor ?>" class="p-3 text-sm font-mono shadow bg-white rounded flex items-center">
-          <img src="https://github.com/<?= $contributor ?>.png?size=32" style="border-radius: 100%" class="mr-3" width="32" height="32" loading="lazy"> @<?= $contributor ?>
+          <img src="https://github.com/<?= $contributor ?>.png?size=32" style="border-radius: 100%; width: auto" class="mr-3" width="32" height="32" loading="lazy"> @<?= $contributor ?>
         </a>
       </li>
       <?php endforeach ?>


### PR DESCRIPTION
Here's the first round of my suggestions for the release page.
I didn't find the time to look at the updated release notes yet. Will do so tomorrow morning.

What I noticed is that the tables in the Core Refactoring and Deprecated sections are too narrow for the many columns. IMO we either need to replace the tables with a different layout element or make these two sections full-width.