### PR TITLE
3.6 release notes: split image option example

### DIFF
--- a/content/releases/3-6/release.txt
+++ b/content/releases/3-6/release.txt
@@ -441,15 +441,18 @@ Thank you to our amazing community for your ongoing support. Without all your fe
 
 ImageOptions:
 
-```yaml
+```yaml "/site/blueprints/site.yml"
 sections:
   recipes:
     headline: Recipes
     type: pages
     info: "{{ page.categoryLabel }}"
-    image:
-      icon: "{{ page.categoryIcon }}"
-      query: false
-      color: black
-      back: "{{ page.categoryColor }}"
+```
+<br>
+```yaml "/site/blueprints/pages/recipe.yml"
+image:
+  icon: "{{ page.categoryIcon }}"
+  query: false
+  color: black
+  back: "{{ page.categoryColor }}"
 ```

--- a/site/snippets/templates/release-36/image-options.php
+++ b/site/snippets/templates/release-36/image-options.php
@@ -4,7 +4,7 @@
       <?php snippet('templates/features/intro', [
         'title' => 'Image options',
         'intro' => 'Improve your previews with custom queries',
-        'text'  => 'You can now set custom backgrounds, icons, images and more for your pages via blueprint settings.'
+        'text'  => 'You can now set custom backgrounds, icons, images and more for your pages via blueprint settings. Per page, not just per section.'
       ]) ?>
       <?= $page->imageOptions()->kt() ?>
     </div>


### PR DESCRIPTION
<img width="1249" alt="Screen Shot 2021-11-16 at 18 06 12" src="https://user-images.githubusercontent.com/3788865/142031789-31d1dea0-4c64-4816-9358-93b406b12700.png">
