### PR TITLE
Bugfix on "batch update" cookbook recipe

### DIFF
--- a/content/docs/2_cookbook/2_content/0_batch-update/cookbook-recipe.txt
+++ b/content/docs/2_cookbook/2_content/0_batch-update/cookbook-recipe.txt
@@ -333,7 +333,7 @@ return [
                     $list = F::read($logfile);
 
                     // ...or build it from the index
-                    if ($list == null || $offset !== 0) {
+                    if ($list == null) {
 
                         $collection = site()->index(true);
 


### PR DESCRIPTION
An annoying little bug, which I only discovered while ("eat your own cooking" :man_cook:) working with a particularly big set of pages: the script worked just fine, but kept re-indexing the entire batch instead of fulfilling the promise of that final iteration. With this fix, it now works as advertised – only reading `$kirby->index()` on the first run and then taking the list from the log file.