### PR TITLE
fix(docs): update k-dialog example to match props

### DIFF
--- a/content/docs/3_reference/7_plugins/4_ui/0_dialog/reference-ui.txt
+++ b/content/docs/3_reference/7_plugins/4_ui/0_dialog/reference-ui.txt
@@ -11,7 +11,7 @@ By default, the dialog component is coming with cancel and submit buttons in the
 
 <k-dialog
   ref="dialog"
-  button="Delete"
+  submitButton="Delete"
   theme="negative"
   icon="trash"
 >


### PR DESCRIPTION
I found a very small issue in the `<k-dialog>` example. The attribute to change the submit button text isn't `button` but `buttonText` according to the described properties.