### PR TITLE
Fix typo

### DIFF
--- a/content/docs/3_reference/4_objects/cms/0_user/0_logout/reference-classmethod.txt
+++ b/content/docs/3_reference/4_objects/cms/0_user/0_logout/reference-classmethod.txt
@@ -9,7 +9,7 @@ if($user = $kirby->user()) {
   $user->logout();
 }
 
-go('login');
+go('panel/login');
 
 ?>
 ```

--- a/content/docs/3_reference/4_objects/cms/0_user/0_logout/reference-classmethod.txt
+++ b/content/docs/3_reference/4_objects/cms/0_user/0_logout/reference-classmethod.txt
@@ -9,7 +9,8 @@ if($user = $kirby->user()) {
   $user->logout();
 }
 
-go('panel/login');
+// do something, e.g. redirect to a custom login page
+go('login');
 
 ?>
 ```


### PR DESCRIPTION
`go('login')` does not work, unless such path is configured as a custom route