### PR TITLE
Fix kirby variable for algolia error

### DIFF
--- a/site/snippets/kirbytext/since.php
+++ b/site/snippets/kirbytext/since.php
@@ -1,5 +1,5 @@
 <?php
-$current = version_compare($version, $kirby->version(), '>=');
+$current = version_compare($version, kirby()->version(), '>=');
 ?>
 
 <summary <?php e($current, 'class="new"') ?>>


### PR DESCRIPTION
Fix for:

> Error: Call to a member function version() on null in file /home/runner/work/getkirby.com/getkirby.com/site/snippets/kirbytext/since.php on line 2