### PR TITLE
Add that custom slug rules overwrite the slug-option

### DIFF
--- a/content/docs/3_reference/6_system/1_options/0_slugs/reference-article.txt
+++ b/content/docs/3_reference/6_system/1_options/0_slugs/reference-article.txt
@@ -15,7 +15,7 @@ return [
 
 ```
 
-Additionally, you can define custom rules:
+Alternatively, you can define custom rules:
 
 ```php  "/site/config/config.php"
 Str::$language = [
@@ -23,7 +23,7 @@ Str::$language = [
 ];
 ```
 
-These custom rules have to be stored in a (link: docs/guide/plugins/plugin-basics text: plugin).
+These custom rules have to be stored in a (link: docs/guide/plugins/plugin-basics text: plugin). Custom rules overwrite the `slugs` option.
 
 ## Set allowed max length of slugs
 


### PR DESCRIPTION
Page: https://getkirby.com/docs/reference/system/options/slugs

I had to learn the hard way, that `Str::$language = ['&' => 'und'];` overwrites `'slugs' => 'de'`.
In the docs it currently says:

>You can set the slug option. Additionally you can use custom rules.

But it's not additional. Custom rules overwrite the slug option.

I use merge now but I'm not sure if this has a place in the docs:

```php
Str::$language = array_merge(Str::$language, [
  '&' => 'und'
]);
```

What's most important is that it doesn't say "additionally" because that's misleading.