### PR TITLE
Improve accessibility of markup for breadcrumb example

### DIFF
--- a/content/docs/2_cookbook/3_templating/0_menus/cookbook-recipe.txt
+++ b/content/docs/2_cookbook/3_templating/0_menus/cookbook-recipe.txt
@@ -221,12 +221,12 @@ if($items->isNotEmpty()):
 ## Breadcrumb menu
 
 ```php
-<nav>
-  <ul>
+<nav aria-label="breadcrumb">
+  <ol>
     <?php foreach($site->breadcrumb() as $crumb): ?>
-    <li<?php e($crumb->isActive(), ' class="is-active"') ?>><a href="<?= $crumb->url() ?>"><?= $crumb->title()->html() ?></a></li>
+    <li<?php e($crumb->isActive(), ' aria-current="location"') ?>><a href="<?= $crumb->url() ?>"><?= $crumb->title()->html() ?></a></li>
     <?php endforeach; ?>
-  </ul>
+  </ol>
 </nav>
 ```
 


### PR DESCRIPTION
To follow some accessibility best practices for breadcrumb menus, introduce a label for the breadcrumb navigation wrapper, switch the list to an ordered list to denote the hierarchy and replace the active class with the correct aria attribute.