### PR TITLE
Plugins: examples without copy button

### DIFF
--- a/assets/css/site/code.css
+++ b/assets/css/site/code.css
@@ -38,6 +38,9 @@
 .code-toolbar:hover .toolbar {
   opacity: 1;
 }
+[data-no-copy] .code-toolbar .toolbar {
+  opacity: 0;
+}
 .code-toolbar button {
   position: relative;
   display: flex;

--- a/site/snippets/templates/plugins/cards.php
+++ b/site/snippets/templates/plugins/cards.php
@@ -8,7 +8,9 @@
           <?php elseif ($plugin->example()->isNotEmpty()) : ?>
             <div style="--aspect-ratio: 2/1; background: #000; overflow:hidden">
               <div class="flex items-center justify-center <?= ($columns ?? 3) === 3 ? ' text-xs' : '' ?>">
-                <div class="shadow-xl"><?= $plugin->example()->kt() ?></div>
+                <div class="shadow-xl" data-no-copy>
+                  <?= $plugin->example()->kt() ?>
+                </div>
               </div>
             </div>
           <?php else : ?>

--- a/site/snippets/templates/plugins/hero.php
+++ b/site/snippets/templates/plugins/hero.php
@@ -17,7 +17,9 @@
           <div class="px-6 pt-6">
             <div class="shadow-xl" style="--aspect-ratio: 2/1; background: #000; border-top-left-radius: var(--rounded); border-top-right-radius: var(--rounded); overflow:hidden">
               <div class="flex items-center justify-center">
-                <div class="shadow-xl"><?= $plugin->example()->kt() ?></div>
+                <div class="shadow-xl" data-no-copy>
+                  <?= $plugin->example()->kt() ?>
+                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
@bastianallgeier could be solved this way. Or we extract some of the plugin CSS in a CSS file itself and add a custom CSS rule there without the need for `data-no-copy`