### PR TITLE
[plugin] Add dist download url for trevor

### DIFF
--- a/content/plugins/rasteiner/trevor/plugin.txt
+++ b/content/plugins/rasteiner/trevor/plugin.txt
@@ -6,6 +6,10 @@ Repository: https://github.com/rasteiner/k3-trevor-view
 
 ----
 
+Download: https://api.github.com/repos/rasteiner-dist/k3-trevor-view/zipball
+
+----
+
 Category: i18n
 
 ----


### PR DESCRIPTION
Trevor should be downloaded from the dist repository (the same from where composer gets it), this repo guarantees that the version number in composer.json is correct and it only includes the production files. 