### PR TITLE
Add type for each cache

### DIFF
--- a/content/docs/3_reference/6_system/1_options/0_cache/reference-article.txt
+++ b/content/docs/3_reference/6_system/1_options/0_cache/reference-article.txt
@@ -37,13 +37,13 @@ return [
 
 The following cache drivers are available:
 
-| Cache Driver | Description |
-| ---- | ---- |
-| FileCache | File System Cache Driver |
-| ApcuCache | Driver for Apcu cache |
-| MemCached | Driver for Memcached cache server |
-| MemoryCache | Driver for caching the current request in memory |
-| NullCache | Dummy Cache Driver (does not do any caching) |
+| Cache Driver | Type | Description |
+| ---- | ---- | ---- |
+| FileCache | file | File System Cache Driver |
+| ApcuCache | apcu | Driver for Apcu cache |
+| MemCached | memcached | Driver for Memcached cache server |
+| MemoryCache | memory | Driver for caching the current request in memory |
+| NullCache | | Dummy Cache Driver (does not do any caching) |
 
 You can also set a registered custom cache driver here. Check out the plugin reference (link: docs/reference/plugins/extensions/cache-drivers text: how to create a custom cache driver).
 


### PR DESCRIPTION
Added the type to be used in Kirby as it isn't indicated anywhere in the documentation.

There is no type for the NullCache (absent in `$this->extensions['cacheTypes']`)