### PR TITLE
Improve invalid() documentation

### DIFF
--- a/content/docs/3_reference/2_templates/0_helpers/0_invalid/reference-helper.txt
+++ b/content/docs/3_reference/2_templates/0_helpers/0_invalid/reference-helper.txt
@@ -30,7 +30,7 @@ if($invalid = invalid($data, $rules, $messages)) {
 }
 ```
 
-You can change these rules based on the type of data you want to obtain and use (link: docs/reference/system/validators text: Kirby's validators) or your own (link: docs/reference/plugins/extensions/validators text: custom validators) to make sure you get the desired data.
+You can change these rules based on the type of data you want to obtain and use (link: docs/reference/system/validators text: Kirby's validators) or your own (link: docs/reference/plugins/extensions/validators text: custom validators).
 
 You can also separately define a message for each validation rule:
 
@@ -44,3 +44,5 @@ $messages = [
   ]
 ];
 ```
+
+You can find an example of `invalid()` used to create pages from frontend in (link: https://getkirby.com/docs/cookbook/forms/creating-pages-from-frontend text: this recipe).

--- a/content/docs/3_reference/2_templates/0_helpers/0_invalid/reference-helper.txt
+++ b/content/docs/3_reference/2_templates/0_helpers/0_invalid/reference-helper.txt
@@ -30,6 +30,7 @@ if($invalid = invalid($data, $rules, $messages)) {
 }
 ```
 
+You can change these rules based on the type of data you want to obtain and use (link: docs/reference/system/validators text: Kirby's validators) or your own (link: docs/reference/plugins/extensions/validators text: custom validators) to make sure you get the desired data.
 
 You can also separately define a message for each validation rule:
 


### PR DESCRIPTION
`invalid()` documentation could be improved with some existing references in Kirby's documentation:

- Added links to Kirby's validators documentation
- Added link to _Creating pages from frontend_ recipe (using `invalid()`)
