### PR TITLE
Add <?php

### DIFF
--- a/content/docs/1_guide/3_troubleshooting/4_debugging/guide.txt
+++ b/content/docs/1_guide/3_troubleshooting/4_debugging/guide.txt
@@ -11,6 +11,7 @@ Kirby honours your PHP error logging settings by default. If you've switched off
 Especially on your local machine, we recommend to switch on error logging in your `php.ini`. Kirby also has a (link: /docs/reference/system/options/debug text: built-in option) which tries to enforce this:
 
 ```php "/site/config/config.php"
+<?php 
 return [
     'debug' => true
 ];


### PR DESCRIPTION
Seems like a small change but if a newbie copies without the <?php the site will be broken and they have no idea why. I encountered this problem a couple of times in workshops.