### PR TITLE
Fix two potential problems in the JS code sample

### DIFF
--- a/content/docs/2_cookbook/3_templating/0_ajax-load-more/cookbook-recipe.txt
+++ b/content/docs/2_cookbook/3_templating/0_ajax-load-more/cookbook-recipe.txt
@@ -202,12 +202,12 @@ const button  = document.querySelector('.load-more');
 let page      = parseInt(element.getAttribute('data-page'));
 
 const fetchProjects = async () => {
-  let url = `${window.location.href}.json/page:${page}`;
+  let url = `${window.location.href.split('#')[0]}.json/page:${page}`;
   try {
     const response       = await fetch(url);
     const { html, more } = await response.json();
     button.hidden        = !more;
-    element.innerHTML    += html;
+    element.insertAdjacentHTML('beforeend', html);
     page++;
   } catch (error) {
     console.log('Fetch error: ', error);


### PR DESCRIPTION
Prevent URLs with hashes from messing up the JSON loading with fetch. Omit .innerHTML when inserting the HTML result, so event listeners and other attached code are kept intact.