### PR TITLE
Fix for missing $page variable in complex grouping example

### DIFF
--- a/content/docs/2_cookbook/2_content/0_grouping-collections/cookbook-recipe.txt
+++ b/content/docs/2_cookbook/2_content/0_grouping-collections/cookbook-recipe.txt
@@ -97,9 +97,9 @@ We can make things even more complex. Have a look at this example:
 
 ```php
 $groupedItems = page('events')->children()->listed()->map(function($p) {
-    $p->eventDate = $p->from()->toDate('d.m.Y') . ' - ' . $page->to()->toDate('d.m.Y');
+    $p->eventDate = $p->from()->toDate('d.m.Y') . ' - ' . $p->to()->toDate('d.m.Y');
 
-    return $page;
+    return $p;
 })->groupBy('eventDate');
 ```
 


### PR DESCRIPTION
Change `$page` to `$p` in complex grouping scenario example to fix undefined variable error. The callback of the `map` function in the example is being passed the page object as `$p` (see line 99) but then refers to it as `$page` later in the callback (see line 100 and 102).