### PR TITLE
Correct link to Extending core Blocks

### DIFF
--- a/content/docs/3_reference/3_panel/3_fields/0_blocks/reference-article.txt
+++ b/content/docs/3_reference/3_panel/3_fields/0_blocks/reference-article.txt
@@ -213,7 +213,7 @@ Kirby's built-in blocktypes are not enough? Create your own! Check out our exten
 
 From modifying the output to how they are previewed in the Panel, you can also overwrite Kirby's built-in block types:
 
-- (link: docs/cookbook/panel/block-basics#extending-core-blocks text: Modifying blocks types and custom blocks)
+- (link: docs/cookbook/panel/block-basics#extending-core-blocks text: Extending core blocks)
 - (link: https://getkirby.com/docs/reference/panel/blocks text: Block types)
 
 (docs: blocks/blocks)

--- a/content/docs/3_reference/3_panel/3_fields/0_blocks/reference-article.txt
+++ b/content/docs/3_reference/3_panel/3_fields/0_blocks/reference-article.txt
@@ -213,7 +213,7 @@ Kirby's built-in blocktypes are not enough? Create your own! Check out our exten
 
 From modifying the output to how they are previewed in the Panel, you can also overwrite Kirby's built-in block types:
 
-- (link: docs/cookbook/block-basics text: Modifying blocks types and custom blocks)
+- (link: docs/cookbook/panel/block-basics#extending-core-blocks text: Modifying blocks types and custom blocks)
 - (link: https://getkirby.com/docs/reference/panel/blocks text: Block types)
 
 (docs: blocks/blocks)


### PR DESCRIPTION
The link to Extending core blocks cook book recipe is returning a 404. 
Now it links to the correct location.