### PR TITLE
root URL warning in the autodetect feature

### DIFF
--- a/content/docs/1_guide/8_languages/1_introduction/guide.txt
+++ b/content/docs/1_guide/8_languages/1_introduction/guide.txt
@@ -235,6 +235,11 @@ return [
 ]
 ```
 
+<warning>
+Using the [root URL for the default language](#language-specific-urls) will disable automatic language detection.
+</warning>
+
+
 ## Language specific SmartyPants
 
 See (link: docs/reference/system/options/smartypants text: SmartyPants config option)


### PR DESCRIPTION
If you use "root urls for the default language" and then, later, try to setup automatic language detection, you might overlook the fact that it won't work, because you're **focusing on the detection thing**, not the fact that you **disabled it by the other setting**.

This might save someone _hours_ in the future. Not that anybody would waste hours on overlooking such thing, _of course_.