### PR TITLE
Add accessible name to the input search

### DIFF
--- a/content/docs/2_cookbook/2_content/0_search/cookbook-recipe.txt
+++ b/content/docs/2_cookbook/2_content/0_search/cookbook-recipe.txt
@@ -29,7 +29,7 @@ Create a new `search.php` template file in `/site/templates`. The search templat
 <?php snippet('header') ?>
 
 <form>
-  <input type="search" title="Search" name="q" value="<?= html($query) ?>">
+  <input type="search" aria-label="Search" name="q" value="<?= html($query) ?>">
   <input type="submit" value="Search">
 </form>
 

--- a/content/docs/2_cookbook/2_content/0_search/cookbook-recipe.txt
+++ b/content/docs/2_cookbook/2_content/0_search/cookbook-recipe.txt
@@ -29,7 +29,7 @@ Create a new `search.php` template file in `/site/templates`. The search templat
 <?php snippet('header') ?>
 
 <form>
-  <input type="search" name="q" value="<?= html($query) ?>">
+  <input type="search" title="Search" name="q" value="<?= html($query) ?>">
   <input type="submit" value="Search">
 </form>
 


### PR DESCRIPTION
The code of the form is not accessible. The input field did not have an accessible name. Added a title to provide one.

Alternatively if the title attribute is unwanted one could use an aria-label:
`<input type="search"aria-label="Search" name="q" value="<?= html($query) ?>">`