### PR TITLE
Docs: Fixed markdown syntax for blocks.php snippet

### DIFF
--- a/site/snippets/docs/blocks/blocks.php
+++ b/site/snippets/docs/blocks/blocks.php
@@ -22,6 +22,7 @@ You don't need to render the HTML for each individual block in the loop though. 
 <?php endforeach ?>
 CODE;
 ?>
+
 ```
 
 ### Manually loading snippets


### PR DESCRIPTION
Due to the missing empty line, there was an incorrect representation of the content.

[getkirby.com/docs - Reference page](https://getkirby.com/docs/reference/panel/fields/blocks#blocks-in-your-templates__looping-through-blocks)