### PR TITLE
Add `sort` option to page blueprint doc

### DIFF
--- a/content/docs/3_reference/3_panel/1_blueprints/0_page/reference-article.txt
+++ b/content/docs/3_reference/3_panel/1_blueprints/0_page/reference-article.txt
@@ -189,6 +189,7 @@ With options, you can control all the page actions that should or should not be 
 | `duplicate` | `true`/`false` (since v3.2.0)|
 | `preview` | `true`/`false`/template string (see below) |
 | `read` | `true`/`false` |
+| `sort` | `true`/`false` |
 | `update` | `true`/`false` |
 
 (docs: permissions/option-permissions)


### PR DESCRIPTION
I couldn’t find a way to disable certain users from sorting a page. Turns out that I can set the `sort` option on the page blueprint, but it was missing in the docs.