### PR TITLE
Extend plugin JSON template for update check

### DIFF
--- a/content/security/security.txt
+++ b/content/security/security.txt
@@ -106,12 +106,12 @@ Each entry MAY have the following fields (required fields are marked with a `*`)
 - `upgrade` (*): URL to a page with migration information for users upgrading from this version range to the latest major release
 - `download`: URL to a ZIP file with the `kirby` folder of a particular version
 
-All fields MAY use the following placeholders in the URL templates:
+All fields MAY use the following placeholders in the URL templates that are dynamically replaced by the client:
 
-- `$version`: A version in the version range of the entry's key
-- `$current`: The current Kirby version of the installation
+- `{{ version }}`: A version in the version range of the entry's key
+- `{{ current }}`: The current Kirby version of the installation
 
-The `changes` and `download` fields MUST use the `$version` placeholders.
+The `changes` and `download` fields MUST use the `{{ version }}` placeholder.
 
 ## `Incidents` field
 
@@ -142,6 +142,11 @@ Each message entry MAY have the following fields (required fields are marked wit
 ----
 
 Versions:
+
+# Static placeholders (filled by getkirby.com):
+# - `{{ latest }} `: Version number of latest release
+# - `{{ latestMajor }}`: Version number of latest release (major part only)
+# - `{{ no-vulnerabilities }}`: Minimum version number without vulnerabilities
 
 {{ latest }}:
     status: latest
@@ -178,16 +183,24 @@ Versions:
 
 Urls:
 
+# Static placeholders (filled by getkirby.com):
+# - `{{ latest }} `: Version number of latest release
+# - `{{ latestMajor }}`: Version number of latest release (major part only)
+# - `{{ no-vulnerabilities }}`: Minimum version number without vulnerabilities
+# Dynamic placeholders (filled by the client):
+# - `{{ version }}`: A version in the version range of the entry's key
+# - `{{ current }}`: The current Kirby version of the installation
+
 3.*:
-    changes: https://github.com/getkirby/kirby/releases/tag/$version
-    download: https://github.com/getkirby/kirby/archive/refs/tags/$version.zip
+    changes: https://github.com/getkirby/kirby/releases/tag/{{ version }}
+    download: https://github.com/getkirby/kirby/archive/refs/tags/{{ version }}.zip
     upgrade: https://getkirby.com/releases/{{ latestMajor }}
 2.*:
-    changes: https://github.com/getkirby-v2/kirby/releases/tag/$version
-    download: https://github.com/getkirby-v2/kirby/archive/refs/tags/$version.zip
+    changes: https://github.com/getkirby-v2/kirby/releases/tag/{{ version }}
+    download: https://github.com/getkirby-v2/kirby/archive/refs/tags/{{ version }}.zip
     upgrade: https://getkirby.com/releases/{{ latestMajor }}
 1.*:
-    changes: https://github.com/getkirby-v1/starterkit/releases/tag/$version
+    changes: https://github.com/getkirby-v1/starterkit/releases/tag/{{ version }}
     upgrade: https://getkirby.com/releases/{{ latestMajor }}
 
 ----

--- a/kirby/config/methods.php
+++ b/kirby/config/methods.php
@@ -503,7 +503,7 @@ return function (App $app) {
 		 * @param string $fallback Fallback for tokens in the template that cannot be replaced
 		 * @return \Kirby\Cms\Field
 		 */
-		'replace' => function (Field $field, array $data = [], string $fallback = '') use ($app) {
+		'replace' => function (Field $field, array $data = [], string|null $fallback = '') use ($app) {
 			if ($parent = $field->parent()) {
 				// never pass `null` as the $template to avoid the fallback to the model ID
 				$field->value = $parent->toString($field->value ?? '', $data, $fallback);

--- a/kirby/src/Cms/ModelWithContent.php
+++ b/kirby/src/Cms/ModelWithContent.php
@@ -531,7 +531,7 @@ abstract class ModelWithContent extends Model
 	 * @param string $handler For internal use
 	 * @return string
 	 */
-	public function toString(string $template = null, array $data = [], string $fallback = '', string $handler = 'template'): string
+	public function toString(string $template = null, array $data = [], string|null $fallback = '', string $handler = 'template'): string
 	{
 		if ($template === null) {
 			return $this->id() ?? '';

--- a/site/models/plugin.php
+++ b/site/models/plugin.php
@@ -25,26 +25,49 @@ class PluginPage extends Page
         return $this->images()->findBy('name', 'card');
     }
 
-    public function download()
+    public function changes($version = null)
+    {
+        if ($this->content()->has('changes')) {
+            return $this->content()->get('changes')->value();
+        }
+
+        $url = $this->repository()->value();
+
+        if (Str::contains($url, 'github')) {
+            if ($version) {
+                return $url . '/releases/tag/' . $version;
+            }
+
+            return $url . '/releases/latest';
+        }
+
+        return $url;
+    }
+
+    public function download($version = null)
     {
         if ($this->content()->has('download')) {
             return $this->content()->get('download')->value();
         }
 
-        $url   = $this->repository()->value();
-        $branch = $this->branch()->value() ?? 'master';
+        $url    = $this->repository()->value();
+        $object = $version ?? $this->branch()->value() ?? 'master';
 
         if (Str::contains($url, 'github')) {
+            if ($version) {
+                return $url . '/archive/refs/tags/' . $version . '.zip';
+            }
+
             return rtrim(Str::replace($url, 'github.com', 'api.github.com/repos'), '/') . '/zipball';
         }
 
         if (Str::contains($url, 'bitbucket')) {
-            return $url . '/get/' . $branch . '.zip';
+            return $url . '/get/' . $object . '.zip';
         }
 
         if (Str::contains($url, 'gitlab')) {
             $repo = basename($url);
-            return $url . '/-/archive/' . $branch . '/' . $repo . '-' . $branch . '.zip';
+            return $url . '/-/archive/' . $object . '/' . $repo . '-' . $object . '.zip';
         }
 
         return $url;
@@ -136,8 +159,8 @@ class PluginPage extends Page
 
     public function toJson($onlyIfCached = false)
     {
-
         $screenshot = $this->images()->findBy('name', 'screenshot');
+        $version    = $this->version($onlyIfCached);
 
         return [
             'title'  => $this->title()->value(),
@@ -151,7 +174,29 @@ class PluginPage extends Page
             'category'    => option('plugins.categories.' . $this->category() . '.label'),
             'description' => $this->description()->value(),
             'screenshot'  => $screenshot ? $screenshot->url() : null,
-            'version'     => $this->version($onlyIfCached)
+
+            // basic skeleton for the update check (can be extended later)
+            'latest'   => $version,
+            'versions' => [
+                $version => [
+                    'description' => 'Latest release',
+                    'status'      => 'latest'
+                ],
+                '*' => [
+                    'description' => 'Actively supported',
+                    'latest'      => $version,
+                    'status'      => 'active-support'
+                ]
+            ],
+            'urls' => [
+                '*' => [
+                    'changes'  => $this->changes('$version'),
+                    'download' => $this->download('$version'),
+                    'upgrade'  => $this->repository()->value(),
+                ]
+            ],
+            'incidents' => [],
+            'messages'  => []
         ];
 
     }

--- a/site/models/plugin.php
+++ b/site/models/plugin.php
@@ -190,6 +190,10 @@ class PluginPage extends Page
             ],
             'urls' => [
                 '*' => [
+                    // `$version` is wrapped in strings on purpose
+                    // because it is a template placeholder for the
+                    // URL templates (so that the update check can
+                    // insert any version into the template)
                     'changes'  => $this->changes('$version'),
                     'download' => $this->download('$version'),
                     'upgrade'  => $this->repository()->value(),

--- a/site/models/plugin.php
+++ b/site/models/plugin.php
@@ -190,12 +190,11 @@ class PluginPage extends Page
             ],
             'urls' => [
                 '*' => [
-                    // `$version` is wrapped in strings on purpose
-                    // because it is a template placeholder for the
-                    // URL templates (so that the update check can
-                    // insert any version into the template)
-                    'changes'  => $this->changes('$version'),
-                    'download' => $this->download('$version'),
+                    // `{{ version}}` is a template placeholder for
+                    // the URL templates (so that the update check
+                    // can insert any version into the URLs)
+                    'changes'  => $this->changes('{{ version }}'),
+                    'download' => $this->download('{{ version }}'),
                     'upgrade'  => $this->repository()->value(),
                 ]
             ],

--- a/site/models/security.php
+++ b/site/models/security.php
@@ -50,12 +50,12 @@ class SecurityPage extends Page
 
     public function urls()
     {
-        return parent::urls()->replace($this->replace())->toStructure();
+        return parent::urls()->replace($this->replace(), null)->toStructure();
     }
 
     public function versions()
     {
-        return parent::versions()->replace($this->replace())->toStructure();
+        return parent::versions()->replace($this->replace(), null)->toStructure();
     }
 
     public function versionsTable()
@@ -69,7 +69,7 @@ class SecurityPage extends Page
             'incidents' => $this->incidentsTable(),
             'messages'  => $this->messagesTable(),
             'versions'  => $this->versionsTable()
-        ]));
+        ]), null);
     }
 
 }

--- a/site/templates/plugin.json.php
+++ b/site/templates/plugin.json.php
@@ -1,1 +1,8 @@
-<?= json_encode($page->toJson(), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+<?php
+
+// keep the data in the client cache for a day,
+// but refresh the data in the CDN cache every half an hour;
+// if getkirby.com is not reachable, continue to serve the data for two days
+$kirby->response()->header('Cache-Control', 'max-age=86400, s-maxage=1800, stale-if-error=172800');
+
+echo json($page->toJson());


### PR DESCRIPTION
This enables the Panel update check for plugins.

I suggest to start simple with hardcoded update data. Once we have the plugin hub, we can make all of this configurable so that plugin devs can e.g. also submit vulnerabilities and control which versions are free or paid upgrades.