### PR TITLE
Fix link to basic contact form line 7

### DIFF
--- a/content/docs/2_cookbook/4_forms/0_email-with-attachments/cookbook-recipe.txt
+++ b/content/docs/2_cookbook/4_forms/0_email-with-attachments/cookbook-recipe.txt
@@ -4,7 +4,7 @@ Title: Email with attachments
 
 Text:
 
-This recipe extends the (link: text: basic contact form) example, but this time the user can attach some files. As an example we use a job application form.
+This recipe extends the (link: https://getkirby.com/docs/cookbook/forms/basic-contact-form text: basic contact form) example, but this time the user can attach some files. As an example we use a job application form.
 
 To follow this example, your content structure should look like this:
 

--- a/content/docs/2_cookbook/4_forms/0_email-with-attachments/cookbook-recipe.txt
+++ b/content/docs/2_cookbook/4_forms/0_email-with-attachments/cookbook-recipe.txt
@@ -4,7 +4,7 @@ Title: Email with attachments
 
 Text:
 
-This recipe extends the (link: https://getkirby.com/docs/cookbook/forms/basic-contact-form text: basic contact form) example, but this time the user can attach some files. As an example we use a job application form.
+This recipe extends the (link: docs/cookbook/forms/basic-contact-form text: basic contact form) example, but this time the user can attach some files. As an example we use a job application form.
 
 To follow this example, your content structure should look like this:
 


### PR DESCRIPTION
The "basic contact form" link on line 7 should be: https://getkirby.com/docs/cookbook/forms/basic-contact-form