### PR TITLE
Added fields: to structure reference page example

### DIFF
--- a/content/docs/3_reference/3_panel/3_fields/0_structure/reference-article.txt
+++ b/content/docs/3_reference/3_panel/3_fields/0_structure/reference-article.txt
@@ -70,6 +70,7 @@ You can define any number of fields and use the same (link: docs/reference/panel
 You can set default values for structure fields which will prepopulate the field:
 
 ```yaml
+fields:
   emails:
     label: Emails
     type: structure


### PR DESCRIPTION
Added `fields:` to be congruent with the other examples on that same page. Users who quickly copy and paste to try out this blueprint might forget to manually add `fields:` for this single example.