### PR TITLE
image: color and image: back don't  work when adding a semicolon Semi…

### DIFF
--- a/content/docs/3_reference/3_panel/1_blueprints/0_page/reference-article.txt
+++ b/content/docs/3_reference/3_panel/1_blueprints/0_page/reference-article.txt
@@ -169,7 +169,7 @@ image:
 
 ```yaml
 image:
-  back: "linear-gradient(90deg, rgba(2,0,36,1) 0%, rgba(9,9,121,1) 35%, rgba(0,212,255,1) 100%);"
+  back: "linear-gradient(90deg, rgba(2,0,36,1) 0%, rgba(9,9,121,1) 35%, rgba(0,212,255,1) 100%)"
 ```
 
 


### PR DESCRIPTION
…colon

`image: color:` and `image: back:` don't work when adding a semicolon Semicolon.