### PR TITLE
update ubuntu version to add PHP8

### DIFF
--- a/content/docs/2_cookbook/9_setup/0_kirby-meets-docker/cookbook-recipe.txt
+++ b/content/docs/2_cookbook/9_setup/0_kirby-meets-docker/cookbook-recipe.txt
@@ -364,8 +364,8 @@ In a new folder, e.g. `~/docker-example-2` create a new `Dockerfile`. This time,
 ### Dockerfile
 
 ```Dockerfile "~/docker-example-2/Dockerfile"
-# Use offical ubuntu:20.04 image
-FROM ubuntu:22.10
+# Use latest offical ubuntu image
+FROM ubuntu:latest
 
 # Set timezone environment variable
 ENV TZ=Europe/Berlin
@@ -505,8 +505,8 @@ Then copy the `default.conf` file from the last example into the new folder.
 Next to the `starterkit` folder, create a new Dockerfile. Our Dockerfile looks slightly different than before. This time, we don't need to install Git in the container, and we remove the steps that cloned the Starterkit and the commands that changed the files and directories ownership. With that done, our Dockerfile now looks like this:
 
 ```Dockerfile "~/docker-example-3/Dockerfile"
-# Use offical ubuntu:20.04 image
-FROM ubuntu:20.04
+# Use latest offical ubuntu image
+FROM ubuntu:latest
 
 # Set timezone
 ENV TZ=Europe/Berlin

--- a/content/docs/2_cookbook/9_setup/0_kirby-meets-docker/cookbook-recipe.txt
+++ b/content/docs/2_cookbook/9_setup/0_kirby-meets-docker/cookbook-recipe.txt
@@ -365,7 +365,7 @@ In a new folder, e.g. `~/docker-example-2` create a new `Dockerfile`. This time,
 
 ```Dockerfile "~/docker-example-2/Dockerfile"
 # Use offical ubuntu:20.04 image
-FROM ubuntu:20.04
+FROM ubuntu:22.10
 
 # Set timezone environment variable
 ENV TZ=Europe/Berlin


### PR DESCRIPTION
~/docker-example-2/Dockerfile 
Changed version of ubuntu to ubuntu:22.10 in order to install php version 8+  this php version is needed otherwise Kirby 3.8 will not run. This script as it was will give an error on the 'localhost' kirby page. 

(I am a novice at this, maybe there is a better way to make sure php8 is used. This worked for me)