### PR TITLE
Replace hyphens by camelCase in example of line field

### DIFF
--- a/content/docs/3_reference/3_panel/3_fields/0_line/reference-article.txt
+++ b/content/docs/3_reference/3_panel/3_fields/0_line/reference-article.txt
@@ -33,16 +33,16 @@ fields:
 
   …
 
-  line-a:
+  lineA:
     type: line
 
   …
 
-  line-b:
+  lineB:
     type: line
 
   …
 
-  line-c:
+  lineC:
     type: line
 ```


### PR DESCRIPTION
According to [1], field names should not use hyphens:

> You can only use **alphanumeric characters** and **underscores** in field names.

In my opinion it makes sense to follow that rule in this example. (Even though a line might not be a 'real' field with data, you could be putting users on the wrong foot with such an example.)

[1] https://getkirby.com/docs/guide/blueprints/fields#naming-fields