### PR TITLE
Note: animals.csv should use a semicolon separator

### DIFF
--- a/content/docs/1_guide/17_virtual-pages/4_content-from-csv/guide.txt
+++ b/content/docs/1_guide/17_virtual-pages/4_content-from-csv/guide.txt
@@ -16,6 +16,10 @@ Text:
 
 In this example we are going to read a list of (dummy) animals from a (file: animals.csv text: CSV file) and create virtual pages for each animal.
 
+<info>
+Note: For this example we are using a `.csv`file where fields are separated by a semi-colon. If you are using other separators in your own file, change the separator parameter when calling the `csv()` method below accordingly.
+</info>
+
 ## The parent content folder
 
 Let's create an animals folder for our site, which is used as the parent for all animal subpages.
@@ -28,8 +32,6 @@ content/
 ```
 
 We can put the (file: animals.csv) directly inside this folder to make it nice and clean to read data from that file. You could even provide an uploader for this in the panel later, so your content editors can update the csv file whenever they have a fresh export with updated data.
-
-The .csv file should use a semicolon separator and not a comma separator
 
 ## Reading from the CSV
 

--- a/content/docs/1_guide/17_virtual-pages/4_content-from-csv/guide.txt
+++ b/content/docs/1_guide/17_virtual-pages/4_content-from-csv/guide.txt
@@ -29,6 +29,8 @@ content/
 
 We can put the (file: animals.csv) directly inside this folder to make it nice and clean to read data from that file. You could even provide an uploader for this in the panel later, so your content editors can update the csv file whenever they have a fresh export with updated data.
 
+The .csv file should use a semicolon separator and not a comma separator
+
 ## Reading from the CSV
 
 To convert the CSV from the file to a PHP array we are going to use a little `csv()` helper function. This function is stored in a small plugin. It takes the absolute path to the csv file and returns a nice and clean array.


### PR DESCRIPTION
I am in the U.S. and the default separator for .csv files is a comma. I used your animals.csv example to render my own spreadsheet. The virtual pages were not created. However, they were listed when I changed my .csv separator to a semicolon as in your example (using find and replace). For some reason my .csv files also had quotation marks around each full entry and others around items with a $ sign. To get the example working, I did not use my entries with $ signs and eliminated all quotation marks.