### PR TITLE
fix error if card page level is > 1

### DIFF
--- a/content/docs/2_cookbook/10_panel/0_block-collection/cookbook-recipe.txt
+++ b/content/docs/2_cookbook/10_panel/0_block-collection/cookbook-recipe.txt
@@ -697,7 +697,7 @@ panel.plugin("cookbook/block-factory", {
         "cardType": {
           handler (value) {
            if(value === 'page' && this.pageId) {
-            this.$api.get('pages/' + this.pageId.replace('/', '+')).then(page => {
+            this.$api.get('pages/' + this.pageId.replaceAll('/', '+')).then(page => {
               this.text = page.content.text.replace(/(<([^>]+)>)/gi, "") || this.text;
             });
            } else if(value === 'manual') {
@@ -710,7 +710,7 @@ panel.plugin("cookbook/block-factory", {
         "page": {
           handler (value) {
            if(this.cardType === 'page' && this.pageId) {
-            this.$api.get('pages/' + this.pageId.replace('/', '+')).then(page => {
+            this.$api.get('pages/' + this.pageId.replaceAll('/', '+')).then(page => {
               this.text = page.content.text.replace(/(<([^>]+)>)/gi, "") || this.text;
             });
            } else if(value === 'manual') {


### PR DESCRIPTION
`.replaceAll('/', '+')`only replaces the first slash with a plus in the api call, leading to an error if the selected page is nested deeper than level 1. Using `.replaceAll()`fixes that.