### PR TITLE
Fix incorrect instructions

### DIFF
--- a/content/docs/3_reference/2_templates/0_helpers/reference-helpers.txt
+++ b/content/docs/3_reference/2_templates/0_helpers/reference-helpers.txt
@@ -13,7 +13,7 @@ Text:
 Kirby tries to register its helper functions in PHP's global namespace. This can lead to conflicts when you or a plugin you are using is including other libraries that try to register their own functions globally with same names, e.g. `dump()`. Kirby will throw an error when it detects this - so that this doesn't happen without your notice.
 </warning>
 
-To deactivate one of Kirby's helper functions globally, you need to set a specific constant in your `index.php` to `true`, e.g.
+To deactivate one of Kirby's helper functions globally, you need to set a specific constant in your `index.php` to `false`, e.g.
 
 ```php "/index.php"
 <?php


### PR DESCRIPTION
The documentation currently says the constant needs to be set to `true` to disable the helper method, but it actually needs to be set to `false`.