### PR TITLE
Show README.md from GitHub

### DIFF
--- a/site/controllers/plugin.php
+++ b/site/controllers/plugin.php
@@ -8,16 +8,75 @@ return function ($page) {
     ->filterBy('category', $page->category()->value())
     ->not($page);
 
+  $getFromGitHub = function(Array $paths) {
+
+    $request = Remote::request(implode('/',$paths));
+    
+    if ($request->code() == 200) {
+      return [
+        'url' => $request->url(),
+        'content' => $request->content(),
+        'root' => implode('/',array_slice($paths, 0, -1))
+      ];
+    };
+
+  };
+
+  $readme = function () use ($getFromGitHub){
+
+    if (page()->repository()->isNotEmpty()) {
+
+      $repo_path = 'https://raw.githubusercontent.com/'.Url::path(page()->repository());
+      $result = array();
+      $variations = [
+        ['master', 'README.md'],
+        ['master', 'readme.md'],
+        ['master/.github', 'README.md'],
+        ['master/.github', 'readme.md'],
+        ['main', 'README.md'],
+        ['main', 'readme.md'],
+        ['main/.github', 'README.md'],
+        ['main/.github', 'readme.md'],
+        ['stable', 'README.md'],
+        ['stable', 'readme.md'],
+        ['stable/.github', 'README.md'],
+        ['stable/.github', 'readme.md'],
+      ];
+      
+      //Walk throug Variations
+      foreach($variations as $variation) {
+          if ($result = $getFromGitHub(array_merge([$repo_path], $variation))) {
+            break;
+          };
+      }
+
+      //Debug:
+      //dump($result['url'] ?? "No Url");
+      //dump($result['root'] ?? "No Root");
+
+      //No content
+      if (empty($result)) return;
+
+      //Replace relative paths
+      $result['content'] = preg_replace('/\]\((?!https?:\/\/)/', ']('.$result['root'] . '/', $result['content']);
+      
+      //Parse Mardown and off the post
+      return kirbytext($result['content']);
+
+    }
+  };
+
   if ($page->subcategory()->isNotEmpty()) {
     $related = $related->filterBy('subcategory', $page->subcategory()->value());
   }
-
+  
   return [
     'categories'      => $categories,
     'currentCategory' => $page->category(),
     'download'        => $page->download(),
     'author'          => $page->parent(),
     'authorPlugins'   => $page->siblings(false),
-    'relatedPlugins'  => $related
+    'relatedPlugins'  => $related,
+    'documentation'   => $page->text()->kt()->or($readme())
   ];
 };

--- a/site/templates/plugin.php
+++ b/site/templates/plugin.php
@@ -110,11 +110,25 @@
   .plugin-installation input:focus {
     outline: 0;
   }
+
+  .documentation.prose > * {
+    max-width: 100%;
+  }
+
+  .documentation.prose > h1 {
+    margin-top: 4rem;
+  }
+
+
+  .documentation.prose figure.code {
+    margin-bottom: 1.2rem;
+  }
+
 </style>
 
 <article>
 
-  <header class="mb-<?= $page->text()->isNotEmpty() ? '24' : '42' ?>">
+  <header class="mb-<?= $documentation ? '24' : '42' ?>">
     <h1 class="h1 block mb-12"><?= $page->title() ?></h1>
     <div class="plugin-summary mb-12">
       <figure>
@@ -145,7 +159,7 @@
             </div>
           <?php endif ?>
         </div>
-        <figcaption class="prose text-xl color-black">
+        <figcaption class="prose text-xl color-black mb-12">
           <?= $page->description()->kt()->widont() ?>
         </figcaption>
       </figure>
@@ -232,10 +246,10 @@
 
   </header>
 
-  <?php if ($page->text()->isNotEmpty()) : ?>
+  <?php if ($documentation) : ?>
     <?php snippet('toc', ['title' => 'Documentation']) ?>
-    <div class="prose text-base mb-42">
-      <?= $page->text()->kt() ?>
+    <div class="prose documentation text-base mb-42">
+      <?= $documentation ?>
     </div>
   <?php endif ?>
 


### PR DESCRIPTION
Sometimes it's useful to see the documentation direct from the GitHub-Repository on a plugin page. That's why i create this feature.

**Before you merge it, let me mention something:**
On each call of a plugin page, getkirby.com makes **up to 12 requests** on the GitHub server. I thing this could be problematic. GitHub could see this as a crawling attack and put getkirby.com on a black list. There's tree ways to avoid this:

1. Put the request script on the page. So it's gonna be cached on the first page call. Problem: The content gets obsolete.
2. Create a script, that crawls the readme files at regular intervals.
3. Using repository hooks (Get a push on repo changes). But this needs some interventions from all plugin users.

The core team should decide, if it's smart to merge this branch.