### PR TITLE
Update Batch updating content cookbook-recipe.txt

### DIFF
--- a/content/docs/2_cookbook/2_content/0_batch-update/cookbook-recipe.txt
+++ b/content/docs/2_cookbook/2_content/0_batch-update/cookbook-recipe.txt
@@ -192,7 +192,7 @@ foreach($collection as $page) {
 
     // update the content file
     $page->update([
-        'text' => $blocks
+        'text' => $blocks->toArray()
     ]);
     
 }


### PR DESCRIPTION
The blocks object has to be converted to an array when storing it via `$page->update()`.