### PR TITLE
Chore: Move existing package to wearejust

### DIFF
--- a/content/plugins/wearejust/meta-tags/plugin.txt
+++ b/content/plugins/wearejust/meta-tags/plugin.txt
@@ -2,7 +2,7 @@ Title: Meta Tags
 
 ----
 
-Repository: https://github.com/pedroborges/kirby-meta-tags
+Repository: https://github.com/wearejust/kirby-meta-tags
 
 ----
 


### PR DESCRIPTION
Hi all,
We are using https://github.com/pedroborges/kirby-meta-tags quite a lot. Unfortunately, the package hasn't been updated for quite some time, and we were having issues with PHP 8.2 support. We've opened a PR (https://github.com/pedroborges/kirby-meta-tags/pull/31) for this quite a while ago but unfortunately, there has been no response from the developer.

We're thinking of 'taking' maintenance of this package, and I've tried contacting the developer for quite some time, using different methods (Email, Twitter and Linkedin), without success. No contact at all. Radio silence. Ultimately, we have decided to fork the project, apply the wearejust namespace, and add PHP 8.2 support. We also have some other improvement ideas for the near future.

Although we haven't officially talked to the developer about taking over, we do feel this is the only way. How do you guys feel about this? We are happy to take over the package! Although I would've liked to do this more 'officially' and also add the abandoned status on Packagist.