### PR TITLE
Fix broken link in reference-classmethod.txt

### DIFF
--- a/content/docs/3_reference/4_objects/cms/0_file/0_thumb/reference-classmethod.txt
+++ b/content/docs/3_reference/4_objects/cms/0_file/0_thumb/reference-classmethod.txt
@@ -39,7 +39,7 @@ $options = [
 ];
 ```
 
-You can define presets of options in your `config.php`. (link: docs/guide/templates/resize-images-on-the-fly#presets text: Learn more ›)
+You can define presets of options in your `config.php`. (link: docs/reference/system/options/thumbs text: Learn more ›)
 
 ## Examples
 


### PR DESCRIPTION
In
- https://getkirby.com/docs/reference/objects/cms/file/thumb
there was a broken link referring to 
- https://getkirby.com/docs/guide/templates/resize-images-on-the-fly#presets
which resulted in a 404.

I now pointed the link to
- https://getkirby.com/docs/reference/system/options/thumbs which would make the most sense to me