### PR TITLE
Fixes Type of `data` parameter of Remote::request()

### DIFF
--- a/site/snippets/docs/remote-class-default-params.php
+++ b/site/snippets/docs/remote-class-default-params.php
@@ -4,7 +4,7 @@
 | basicAuth | `string` | `null` | User name and password to use for the `Authorization` header (formatted as `USERNAME:PASSWORD`)
 | body | `bool` | `true` | When `true` returns transfer as string instead of outputting it directly
 | ca | `int|bool|string` | `Remote::CA_INTERNAL` | TLS CA to use, (link: docs/reference/system/options/remote#configuring-the-list-of-allowed-certificate-authorities-cas-for-https-requests text: see details)
-| data | `array` | `[]`  | The data to be sent with the request
+| data | `array|string` | `[]`  | The data to be sent with the request
 | encoding | `string` | `utf-8` | Accepted values: `null`, `''`, `identity`, `gzip`, `br`
 | file | `string` | `null` | Path to file to be uploaded
 | headers | `array` | `[]` | Array of headers to be sent with the request


### PR DESCRIPTION
https://getkirby.com/docs/reference/objects/http/remote/request#params-array
https://getkirby.com/docs/reference/objects/http/remote/get#params-array

The `data` parameter of `Remote::request()` or `Remote::get()` allows arrays or strings – as shown in the API examples of [`Remote::request()`](https://getkirby.com/docs/reference/objects/http/remote/request#kirby-api-examples).

```php
$request = Remote::request('https://yoursite.com/api/pages/notes/children', [
    'method'  => 'POST',
    'headers' => [
        'Content-Type: application/json',
        'Authorization: Basic ' . base64_encode($email . ':' . $password)
    ],
    'data'    => json_encode($data), // <--- STRING
]);
```

See also: https://github.com/getkirby/kirby/blob/main/src/Http/Remote.php#L331