### PR TITLE
fix: sitemap redirection docs

### DIFF
--- a/content/docs/2_cookbook/2_content/0_sitemap/cookbook-recipe.txt
+++ b/content/docs/2_cookbook/2_content/0_sitemap/cookbook-recipe.txt
@@ -67,7 +67,7 @@ return [
 ];
 ```
 
-You can now test the sitemap of your Kirby site by visiting `http://yourdomain.com/sitemap.xml` `http://yourdomain.com/sitemap`. The second route redirects to the first.
+You can now test the sitemap of your Kirby site by visiting `http://yourdomain.com/sitemap.xml` or `http://yourdomain.com/sitemap`. The second route redirects to the first.
 
 
 ## Excluding pages from your sitemap

--- a/content/docs/2_cookbook/2_content/0_sitemap/cookbook-recipe.txt
+++ b/content/docs/2_cookbook/2_content/0_sitemap/cookbook-recipe.txt
@@ -67,7 +67,7 @@ return [
 ];
 ```
 
-You can now visit the sitemap of your Kirby site by browsing `http://yourdomain.com/sitemap` or `http://yourdomain.com/sitemap.xml`. The second route redirects to the first.
+You can now test the sitemap of your Kirby site by visiting `http://yourdomain.com/sitemap.xml` `http://yourdomain.com/sitemap`. The second route redirects to the first.
 
 
 ## Excluding pages from your sitemap


### PR DESCRIPTION
Hi there!

I'm in the process of reading the docs. Hope it's ok if I create PRs for things that seemed wrong to me. This is the first one. On the docs it says under [/sitemap](https://getkirby.com/docs/cookbook/content/sitemap):

> You can now visit the sitemap of your Kirby site by browsing http://yourdomain.com/sitemap or http://yourdomain.com/sitemap.xml. The second route redirects to the first.

while the provided code snippets on that page (correctly) do the opposite, redirecting `/sitemap` to `/sitemap.xml`.