### PR TITLE
Exclude /media/ folder in snippet for enforcing urls without trailing slash

### DIFF
--- a/content/docs/2_cookbook/9_setup/0_trailing-slash/cookbook-recipe.txt
+++ b/content/docs/2_cookbook/9_setup/0_trailing-slash/cookbook-recipe.txt
@@ -25,6 +25,7 @@ The extra rules for the Panel are not needed if you want to enforce URLs without
 
 ``` ".htaccess"
 RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_URI} !^/media
 RewriteRule ^(.*)/$ /$1 [L,R=301]
 ```
 


### PR DESCRIPTION
The current snippet in the cookbook for enforcing urls without trailing slashes will cause a redirection loop for file requests where the files haven't been generated, yet:

``` ".htaccess"
RewriteCond %{REQUEST_FILENAME} !-f
RewriteRule ^(.*)/$ /$1 [L,R=301]
```

Just like in the previous snippet, we need to exclude the /media/ folder from the rule:

``` ".htaccess"
RewriteCond %{REQUEST_FILENAME} !-f
RewriteCond %{REQUEST_URI} !^/media
RewriteRule ^(.*)/$ /$1 [L,R=301]
```
