### PR TITLE
Update reference-classmethod.txt

### DIFF
--- a/content/docs/3_reference/4_objects/cms/0_page/0_search/reference-classmethod.txt
+++ b/content/docs/3_reference/4_objects/cms/0_page/0_search/reference-classmethod.txt
@@ -15,9 +15,6 @@ $results = $page->search('my awesome search')->listed()->filterBy('template', 'a
 // add pagination to the search results
 $results = $page->search('my awesome search')->paginate(20);
 
-// search in certain fields only
-$results = $page->search('my awesome search', 'title|text');
-
 // search for full words only
 $results = $page->search('my awesome->search', ['words' => true]);
 


### PR DESCRIPTION
The syntax `$results = $page->search('my awesome search', 'title|text');` throws the error `Kirby\Cms\Page::search(): Argument #2 ($params) must be of type array, string given, called in {…}` . Needs to be `$results = $page->search('my awesome search', [ 'fields => [ 'title', 'text' ]]);` to succeed.

This is in Kirby 4.0.0-beta.1