### PR TITLE
Add PHP EOL dates to security.json

### DIFF
--- a/content/docs/1_guide/21_security/guide.txt
+++ b/content/docs/1_guide/21_security/guide.txt
@@ -75,7 +75,9 @@ If you do not use HTTPS, your login information and all other data will be submi
 
 ### Use the latest stable PHP version
 
-Many providers unfortunately still offer very old PHP versions which are no longer maintained. Do yourself and your site a favor and always **update to the latest stable PHP version**. This comes with additional security and often performance benefits. If your provider does not provide a new and stable PHP version, it's a good sign to switch to a better provider.
+Many providers unfortunately still offer very old PHP versions which are no longer maintained. Do yourself and your site a favor and always **update to the latest stable PHP version** that is supported by your Kirby version. This comes with additional security and often performance benefits. If your provider does not provide a new and stable PHP version, it's a good sign to switch to a better provider.
+
+If you cannot update to the latest stable PHP version supported by Kirby, make sure to use a PHP version that has security support at the minimum. So-called "end of life" versions receive no security updates and may be vulnerable. You should **never** run your site on an end-of-life version of PHP.
 
 You can check which PHP versions are still supported on the (link: https://php.net/supported-versions.php text: PHP website).
 

--- a/content/security/php-end-of-life/link.txt
+++ b/content/security/php-end-of-life/link.txt
@@ -1,0 +1,5 @@
+Title: PHP end of life
+
+----
+
+Link: docs/guide/security#secure-your-server__use-the-latest-stable-php-version

--- a/content/security/security.txt
+++ b/content/security/security.txt
@@ -113,6 +113,12 @@ All fields MAY use the following placeholders in the URL templates that are dyna
 
 The `changes` and `download` fields MUST use the `{{ version }}` placeholder.
 
+## `Php` field
+
+The `Php` field contains the end-of-life dates of each major PHP release according to https://www.php.net/supported-versions.php. They can be used to warn users who use an unsupported version.
+
+The key of each entry MUST be set to a string of the major PHP release. The value MUST be set to a ISO 8601 date value.
+
 ## `Incidents` field
 
 The `Incidents` field lists all past security incidents (vulnerabilities in Kirby). It allows to check if a particular version is affected by known vulnerabilities. If this is the case, it points to more information and the version(s) that fixed the vulnerability.
@@ -211,6 +217,17 @@ Urls:
 1.*:
     changes: https://github.com/getkirby-v1/starterkit/releases/tag/{{ version }}
     upgrade: https://getkirby.com/releases/{{ latestMajor }}
+
+----
+
+Php:
+
+# End-of-life dates for each major PHP version
+# according to https://www.php.net/supported-versions.php
+
+"8.0": 2023-11-26
+"8.1": 2024-11-25
+"8.2": 2025-12-08
 
 ----
 

--- a/site/models/security.php
+++ b/site/models/security.php
@@ -30,6 +30,11 @@ class SecurityPage extends Page
 		], true);
 	}
 
+	public function php()
+	{
+		return parent::php()->yaml();
+	}
+
 	protected function replace(Field $field, array $data = [])
 	{
 		$noVulns = null;

--- a/site/templates/security.json.php
+++ b/site/templates/security.json.php
@@ -11,6 +11,7 @@ $data = [
     'latest'    => $kirby->version(),
     'versions'  => $page->versions()->toArray($idFilter),
     'urls'      => $page->urls()->toArray($idFilter),
+    'php'       => $page->php(),
     'incidents' => array_values($page->incidents()->toArray($idFilter)),
     'messages'  => array_values($page->messages()->toArray($idFilter))
 ];


### PR DESCRIPTION
Allows warnings in the Panel when the used PHP version is end-of-life.