### PR TITLE
Fix typo

### DIFF
--- a/content/docs/2_cookbook/11_performance/0_lazy-loading/cookbook-recipe.txt
+++ b/content/docs/2_cookbook/11_performance/0_lazy-loading/cookbook-recipe.txt
@@ -2,7 +2,7 @@ Title: Image lazy-loading
 
 ----
 
-Description: Lazy-loading strategies to improve the performance of you site
+Description: Lazy-loading strategies to improve the performance of your site
 
 ----
 


### PR DESCRIPTION
Hi! Found a tiny typo where `you site` should be `your site`.