### PR TITLE
Filter by compatible version

### DIFF
--- a/assets/css/site/filters.css
+++ b/assets/css/site/filters.css
@@ -6,6 +6,7 @@
 }
 .filters svg {
   margin-right: var(--spacing-3);
+	width: 18px;
 }
 .filters hr {
   margin: var(--spacing-3) 0;

--- a/assets/css/site/menu.css
+++ b/assets/css/site/menu.css
@@ -165,3 +165,12 @@
 		margin: 0 0.75rem;
 	}
 }
+
+/* Versions */
+li.compatibility a {
+	display: inline-block;
+}
+
+li.compatibility a:not(:last-child)::after {
+	content: ',';
+}

--- a/assets/css/site/search.css
+++ b/assets/css/site/search.css
@@ -159,3 +159,20 @@
   outline: solid;
   outline: 5px auto -webkit-focus-ring-color;
 }
+
+
+/* compatibility badges */
+.compatibility span {
+	display: inline-block;
+	font-size: .75em;
+	border-radius: .25rem;
+	padding: .1rem .25rem;
+}
+
+.compatibility span[data-version="3"] {
+	background-color: var(--color-yellow-500);
+}
+
+.compatibility span[data-version="4"] {
+	background-color: var(--color-purple-500);
+}

--- a/content/plugins/getkirby/geo/plugin.txt
+++ b/content/plugins/getkirby/geo/plugin.txt
@@ -29,7 +29,7 @@ Composer: getkirby/geo
 
 ----
 
-Versions: 3,4
+Versions: ^3.3 || ^4.0
 
 ----
 

--- a/content/plugins/getkirby/staticache/plugin.txt
+++ b/content/plugins/getkirby/staticache/plugin.txt
@@ -29,7 +29,7 @@ Composer: getkirby/staticache
 
 ----
 
-Versions: 3,4
+Versions: ^3.8 || ^4.0
 
 ----
 

--- a/site/config/versions.php
+++ b/site/config/versions.php
@@ -67,6 +67,7 @@ return [
 	'3.5' => [
 		'title'       => 'Kirby 3.5',
 		'hasDocs'     => true,
+		'hasFilter'   => true,
 		'mainVersion' => '3',
 		'since'       => 'Dec 2020 - Nov 2021',
 		'description' => 'is not the most current version of Kirby and should not be used for new projects.',
@@ -92,6 +93,7 @@ return [
 	'3.6' => [
 		'title'       => 'Kirby 3.6',
 		'hasDocs'     => true,
+		'hasFilter'   => true,
 		'mainVersion' => '3',
 		'since'       => 'Nov 2021 - June 2022',
 		'description' => 'is not the most current version of Kirby and should not be used for new projects.',
@@ -115,6 +117,7 @@ return [
 	'3.7' => [
 		'title'       => 'Kirby 3.7',
 		'hasDocs'     => true,
+		'hasFilter'   => true,
 		'mainVersion' => '3',
 		'since'       => 'June 2022 - Oct 2022',
 		'description' => 'is not the most current version of Kirby and should not be used for new projects.',
@@ -135,6 +138,7 @@ return [
 		],
 	],
 	'3.8' => [
+		'hasFilter'   => true,
 		'subreleases' => [
 			'3.8.1',
 			'3.8.1.1',
@@ -148,7 +152,7 @@ return [
 	'3.9' => [
 		'title'       => 'Kirby 3.9',
 		'hasDocs'     => true,
-		'title'       => 'Kirby 3.9',
+		'hasFilter'   => true,
 		'mainVersion' => '3',
 		'since'       => 'Jan 2023',
 		'link'        => 'https://getkirby.com/docs',
@@ -167,7 +171,7 @@ return [
 	'4.0' => [
 		'title'       => 'Kirby 4.0',
 		'hasDocs'     => true,
-		'title'       => 'Kirby 4.0',
+		'hasFilter'   => true,
 		'mainVersion' => '4',
 		'since'       => 'Dec 2023',
 		'description' => 'is the latest version of Kirby. <br><strong class="color-black">Start new projects with this version!',

--- a/site/controllers/plugins.php
+++ b/site/controllers/plugins.php
@@ -54,7 +54,7 @@ return function ($kirby, $page, $filter) {
 		'heading' => $heading,
 		'plugins' => $plugins,
 		'filter' => $filter,
-		'version' => $version,
+		'currentVersion' => $version,
 		'versions' => $versions,
 	];
 

--- a/site/controllers/plugins.php
+++ b/site/controllers/plugins.php
@@ -1,12 +1,16 @@
 <?php
 
 use Kirby\Cms\Pages;
+use Composer\Semver\Semver;
 
-return function($page, $filter) {
+return function ($kirby, $page, $filter) {
 
 	$categories = option('plugins.categories');
 	$category   = param('category');
+	$version    = param('version');
 	$heading    = 'Featured';
+	$versions   = array_filter($kirby->option('versions'), fn ($item) => ($item['hasFilter'] ?? false) === true);
+	krsort($versions);
 
 	if ($category && array_key_exists($category, $categories) === true) {
 		$plugins = $page
@@ -17,33 +21,41 @@ return function($page, $filter) {
 
 		$plugins = $plugins->filterBy('category', $category);
 		$heading = $categories[$category]['label'];
+	} elseif (empty($version) === false && array_key_exists($version, $versions)) {
+		$category = 'all';
+		$heading  = $version . ' compatible plugins';
+		$plugins  = $page
+			->grandChildren()
+			->filter(function ($plugin) use ($version) {
+				if ($plugin->versions()->isEmpty()) {
+					return false;
+				}
 
+				return Semver::satisfies($version, $plugin->versions()->value());
+			})
+			->sortBy('title', 'asc');
 	} else if ($category === 'all') {
-			$heading  = 'All plugins';
-			$category = 'all';
-			$plugins  = $page
-					->grandChildren()
-					->sortBy('title', 'asc');
-	} else if ($filter === 'v4') {
-			$heading  = 'Kirby 4 plugins';
-			$category = 'v4';
-			$plugins  = $page
-					->grandChildren()
-					->filter('versions', '*=', '4')
-					->sortBy('title', 'asc');
+		$heading  = 'All plugins';
+		$category = 'all';
+		$plugins  = $page
+			->grandChildren()
+			->sortBy('title', 'asc');
 	} elseif ($filter) {
-			$heading = 'Newly added plugins';
-			$plugins = $page->grandChildren()->filterBy('isNew', true);
+		$heading = 'Newly added plugins';
+		$plugins = $page->grandChildren()->filterBy('isNew', true);
 	} else {
 		$category = null;
 		$plugins  = new Pages();
 	}
-		return [
-		'categories'      => $categories,
+
+	return [
+		'categories' => $categories,
 		'currentCategory' => $category,
-		'heading'         => $heading,
-		'plugins'         => $plugins,
-		'filter'          => $filter,
+		'heading' => $heading,
+		'plugins' => $plugins,
+		'filter' => $filter,
+		'version' => $version,
+		'versions' => $versions,
 	];
 
 };

--- a/site/models/plugin.php
+++ b/site/models/plugin.php
@@ -1,5 +1,6 @@
 <?php
 
+use Composer\Semver\Semver;
 use Kirby\Cache\Cache;
 use Kirby\Content\Field;
 use Kirby\Cms\File;
@@ -49,6 +50,15 @@ class PluginPage extends Page
 		}
 
 		return $url;
+	}
+
+	public function compatible(): array|null
+	{
+		if ($this->versions()->isEmpty()) {
+			return null;
+		}
+
+		return array_filter([3, 4], fn($version) => Semver::satisfies($version .'.100', $this->versions()->value()));
 	}
 
 	public function download(string $version = null): string|null

--- a/site/snippets/templates/plugins/cards.php
+++ b/site/snippets/templates/plugins/cards.php
@@ -39,9 +39,16 @@
               <?php endif ?>
             </p>
           </header>
-          <div class="prose text-sm">
+          <div class="prose text-sm mb-3">
             <?= $plugin->description()->excerpt(140) ?>
           </div>
+					<?php if ($compatible = $plugin->compatible()): ?>
+						<div class="compatibility">
+							<?php foreach ($compatible as $version): ?>
+								<span data-version="<?= $version ?>">K<?= $version ?></span>
+							<?php endforeach ?>
+						</div>
+					<?php endif ?>
         </div>
       </article>
     </a>

--- a/site/snippets/templates/plugins/sidebar.php
+++ b/site/snippets/templates/plugins/sidebar.php
@@ -23,15 +23,20 @@
         </a>
       </li>
       <li>
-        <a href="/plugins/v4" <?= ariaCurrent($kirby->request()->path()->toString() === 'plugins/v4') ?>>
-          <?= icon('flash') ?> Kirby 4
-        </a>
-      </li>
-      <li>
         <a href="/plugins/getkirby" <?= ariaCurrent($kirby->request()->path()->toString() === 'plugins/getkirby')  ?>>
           <?= icon('kirby') ?> Official
         </a>
       </li>
+			<li>
+				<a href="#" <?= ariaCurrent(empty($version) === false) ?>>
+					<?= icon('flash') ?> Compatibility
+				</a>
+			</li>
+			<li class="compatibility">
+				<?php foreach ($versions as $key => $version): ?>
+					<a href="/plugins/version:<?= $key ?>" <?= ariaCurrent($version === $key) ?>><?= $key ?></a>
+				<?php endforeach ?>
+			</li>
       <!-- <li>
         <a href="/plugins/new" <?= ariaCurrent($kirby->request()->path()->toString() === 'plugins/new') ?>>
           <?= icon('flash') ?> New

--- a/site/snippets/templates/plugins/sidebar.php
+++ b/site/snippets/templates/plugins/sidebar.php
@@ -34,7 +34,7 @@
 			</li>
 			<li class="compatibility">
 				<?php foreach ($versions as $key => $version): ?>
-					<a href="/plugins/version:<?= $key ?>" <?= ariaCurrent($version === $key) ?>><?= $key ?></a>
+					<a href="/plugins/version:<?= $key ?>" <?= ariaCurrent($currentVersion === $key) ?>><?= $key ?></a>
 				<?php endforeach ?>
 			</li>
       <!-- <li>


### PR DESCRIPTION
I've implemented rough version. I realize there are many shortcomings. I'll proceed according to your reviews. Here few details:

- Filters multiple versions (3.5, 3.6, 3.7, 3.8, 3.9, 4.0 not only 3 or 4)
- Checks based on `Versions` content value that constraint syntax `^3.8 || ^4.0`
- Shows compatible versions on the plugin cards

![screen-capture-1734-Plugins - Kirby CMS-getkirby test](https://github.com/getkirby/getkirby.com/assets/3393422/a0256635-2985-4737-80f2-c6b34a9dc1e6)


