### PR TITLE
Update guide.txt - remove 'form'

### DIFF
--- a/content/docs/1_guide/7_blueprints/2_fields/guide.txt
+++ b/content/docs/1_guide/7_blueprints/2_fields/guide.txt
@@ -119,7 +119,7 @@ text:
 
 ## Field shortcuts
 
-For simple fields that are only used **once** per blueprint , you can use a shortcut. Set the field type as key and `true` as the value:
+For simple fields that are only used **once** per blueprint, you can use a shortcut. Set the field type as key and `true` as the value:
 
 ```yaml
 fields:

--- a/content/docs/1_guide/7_blueprints/2_fields/guide.txt
+++ b/content/docs/1_guide/7_blueprints/2_fields/guide.txt
@@ -2,13 +2,13 @@ Title: Using fields
 
 ----
 
-Intro: Form fields are an essential part of the configuration and have very powerful options.
+Intro: Blueprint fields are an essential part of the configuration and have very powerful options.
 
 ----
 
 Text:
 
-(screencast: https://www.youtube.com/watch?v=cOUmDlvsPaE title: Fun with fields text: Learn how to create intuitive forms for your editors, how to create field layouts, inline help and more.)
+(screencast: https://www.youtube.com/watch?v=cOUmDlvsPaE title: Fun with fields text: Learn how to create intuitive blueprints for your editors, how to create field layouts, inline help and more.)
 
 
 ## Naming fields
@@ -22,7 +22,7 @@ You can choose the names for your fields freely, but there are two limitations:
 You can still use field names that conflict with (link: docs/reference/objects/page text: native page methods). But you will have to call such a field via the `$page->content()->image()` method. We recommend prefixing your field names instead.
 </info>
 
-## Available form fields
+## Available Blueprint fields
 
 (reference: panel/fields)
 

--- a/content/docs/1_guide/7_blueprints/2_fields/guide.txt
+++ b/content/docs/1_guide/7_blueprints/2_fields/guide.txt
@@ -2,7 +2,7 @@ Title: Using fields
 
 ----
 
-Intro: Blueprint fields are an essential part of the configuration and have very powerful options.
+Intro: Fields are an essential part of the configuration and have very powerful options.
 
 ----
 
@@ -22,7 +22,7 @@ You can choose the names for your fields freely, but there are two limitations:
 You can still use field names that conflict with (link: docs/reference/objects/page text: native page methods). But you will have to call such a field via the `$page->content()->image()` method. We recommend prefixing your field names instead.
 </info>
 
-## Available Blueprint fields
+## Available fields
 
 (reference: panel/fields)
 


### PR DESCRIPTION
Technically they are 'form' fields, but for a person reading this page, it should be specifically referencing a 'blueprint' field.