### PR TITLE
improvement: mark pexelfield as compatible with k4

### DIFF
--- a/content/plugins/mauricerenck/pexelsimagefield/plugin.txt
+++ b/content/plugins/mauricerenck/pexelsimagefield/plugin.txt
@@ -22,4 +22,4 @@ Description: A panel field allowing you to search pexels.com for stockphotos and
 
 ----
 
-Versions: 3
+Versions: 3,4


### PR DESCRIPTION
The 2.0.0 version of the pexel image field now works with Kirby 4