### PR TITLE
Update plugin subcategories from `johannschopplich`

### DIFF
--- a/content/plugins/johannschopplich/content-translator/plugin.txt
+++ b/content/plugins/johannschopplich/content-translator/plugin.txt
@@ -14,6 +14,10 @@ Category: i18n
 
 ----
 
+Subcategory: panel
+
+----
+
 Description: Panel plugin to translate content at once with DeepL or other services
 
 ----

--- a/content/plugins/johannschopplich/serp-preview/plugin.txt
+++ b/content/plugins/johannschopplich/serp-preview/plugin.txt
@@ -14,6 +14,10 @@ Category: seo
 
 ----
 
+Subcategory: panel
+
+----
+
 Description: Panel plugin for search engine result page previews
 
 ----


### PR DESCRIPTION
In my last PR (https://github.com/getkirby/getkirby.com/pull/2149) when adding the Content Translator and SERP Preview plugins, I have forgotten to set the `subcategory` field. This PR is a follow-up to fix that.