### PR TITLE
Overwriting the block class

### DIFF
--- a/content/docs/3_reference/7_plugins/1_extensions/0_block-models/reference-extension.txt
+++ b/content/docs/3_reference/7_plugins/1_extensions/0_block-models/reference-extension.txt
@@ -46,7 +46,7 @@ class DefaultBlock extends Block
 
 Kirby::plugin('my/blockModels', [
     'blockModels' => [
-        'Kirby\\Cms\\Block' => DefaultBlock::class,
+        'default' => DefaultBlock::class,
     ]
 ]);
 ```


### PR DESCRIPTION
In my case using the block class name Kirby\Cms\Block as index does not work anymore in Kirby 4. I had to change it to "default".