### PR TITLE
Added explanatory info to Controllers guide TL;DR section

### DIFF
--- a/content/docs/1_guide/6_templates/3_controllers/guide.txt
+++ b/content/docs/1_guide/6_templates/3_controllers/guide.txt
@@ -16,6 +16,7 @@ Text:
 ## TL;DR
 
 - Use a controller for the logic of your templates.
+- Any data returned by a controller’s function is available everywhere in the corresponding template.
 - A controller must have the same file name as the corresponding template file.
 - Save controllers in `/site/controllers`.
 


### PR DESCRIPTION
I'd like to propose adding a bullet point to the TL;DR list on the _Controllers_ guide page, explaining that all data returned by a controller is available everywhere in the template it corresponds to. I believe this is a key aspect of the practical use of controllers and helps conceptually connecting controllers and templates.