### PR TITLE
Less aggressive icon style

### DIFF
--- a/assets/css/site/icons.css
+++ b/assets/css/site/icons.css
@@ -1,5 +1,8 @@
 :where(svg) {
 	fill: currentColor;
+}
+
+:where(svg[viewBox="0 0 24 24"]) {
 	width: 18px;
 	height: 18px;
 }


### PR DESCRIPTION
If we only set the default size for those svgs that actually have the viewport definition of the remix icons, we should run into way fewer issues. 