### PR TITLE
Describe `|` mark separator in Writer field article

### DIFF
--- a/content/docs/3_reference/3_panel/3_fields/0_writer/reference-article.txt
+++ b/content/docs/3_reference/3_panel/3_fields/0_writer/reference-article.txt
@@ -47,6 +47,8 @@ The writer field supports the following marks by default:
 - `clear`
 </since>
 
+The special mark `|` can be used to separate marks in the toolbar by a vertical line.
+
 ```yaml
 fields:
   text:
@@ -55,6 +57,7 @@ fields:
     marks:
       - bold
       - italic
+      - '|'
       - strike
 ```
 


### PR DESCRIPTION
I wanted to replicate the separator between marks that is used in the default configuration of the Writer field, but I couldn't find it anywhere in the docs. I figured it out from the source code.

Hopefully this will help others 🙂 