### PR TITLE
Fix indentation in code blocks

### DIFF
--- a/content/docs/1_guide/16_emails/guide.txt
+++ b/content/docs/1_guide/16_emails/guide.txt
@@ -250,18 +250,18 @@ You can get access to the underlying PHPMailer instance via the `beforeSend` cal
 
 ```php
 $kirby->email([
-    // …
-    'beforeSend' => function ($mailer) {
-        $mailer->SMTPOptions = [
-            'ssl' => [
-                'verify_peer' => false,
-                'verify_peer_name' => false,
-                'allow_self_signed' => true
-            ]
-        ];
+  // …
+  'beforeSend' => function ($mailer) {
+    $mailer->SMTPOptions = [
+      'ssl' => [
+        'verify_peer' => false,
+        'verify_peer_name' => false,
+        'allow_self_signed' => true
+      ]
+    ];
 
-        return $mailer;
-    }
+    return $mailer;
+  }
 ]);
 ```
 
@@ -274,14 +274,14 @@ It can be useful to add embedded images:
 
 ```php
 $kirby->email([
-    // …
-		'template' => 'email',
-    'beforeSend' => function ($mailer) {
-				$image = asset('assets/images/logo.png');
-				$mailer->AddEmbeddedImage($image->root(), 'image', $image->filename(), 'base64', $image->mime());
+  // …
+  'template' => 'email',
+  'beforeSend' => function ($mailer) {
+    $image = asset('assets/images/logo.png');
+    $mailer->AddEmbeddedImage($image->root(), 'image', $image->filename(), 'base64', $image->mime());
 
-        return $mailer;
-    }
+    return $mailer;
+  }
 ]);
 ```
 


### PR DESCRIPTION
I have just seen some wrong indents there:

![screencapture-2024-01-31-19 04 12@2x](https://github.com/getkirby/getkirby.com/assets/9624530/0d0056ee-018c-497a-961b-dc0b19b0b2d6)
![screencapture-2024-01-31-19 04 05@2x](https://github.com/getkirby/getkirby.com/assets/9624530/529ce76d-3137-45be-ab19-c63b776fd5be)
