### PR TITLE
Add how to register more than one function to a hook

### DIFF
--- a/content/docs/3_reference/7_plugins/1_extensions/0_hooks/reference-extension.txt
+++ b/content/docs/3_reference/7_plugins/1_extensions/0_hooks/reference-extension.txt
@@ -72,6 +72,23 @@ Kirby::plugin('your/plugin', [
 ]);
 ```
 
+If you want to register more than one function to a hook, you can simple pass an array of functions:
+
+```php
+Kirby::plugin('your/plugin', [
+    'hooks' => [
+        'page.delete:before' => [
+					 function ($page) {
+            	// do something before a page gets deleted
+        	 },
+					 function ($page) {
+            	// do something else before a page gets deleted
+        	 }
+				],
+    ]
+]);
+```
+
 ### Wildcard hooks
 
 If you want to register the same hook for multiple events, you can register a wildcard hook (either in your config or in a plugin):


### PR DESCRIPTION
I just learned today, that I can actually register more than one function in a plugin to a hook. I added an example for that in the docs. I have not found anything concerning this.