### PR TITLE
Replace dynamic property with passing a callback to the sort() method

### DIFF
--- a/content/docs/2_cookbook/2_content/0_sorting/cookbook-recipe.txt
+++ b/content/docs/2_cookbook/2_content/0_sorting/cookbook-recipe.txt
@@ -149,34 +149,29 @@ Now, instead of numbers, our sizes field contains sizes like `S, M, L, XL, XXL` 
 // fetch the products from the structure field
 $products = $page->products()->toStructure();
 
-// map an order field to each item of the collection
-$products = $products->map(function($item) {
   // array that keeps the order of sizes
   $sizes = ['S', 'M', 'L', 'XL', 'XXL'];
 
-  // get the order number from the array based on the item's size value
-  $item->order = array_search($item->size()->value(), $sizes);
-
-  return $item;
-});
-
-// finally, sort by order
-$products = $products->sortBy('order', 'asc');
+  // sort products by order number based on the item’s size value
+  $producs = $producs->sort(
+    // get the order number from the array
+    fn ($item) => array_search($item->size()->value(), $sizes),
+    SORT_ASC
+  );
 ```
 
 Of course, we can write all that stuff a bit shorter:
 
 ```php
-$products = $page->products()->structure()->map(function($item) {
-  $sizes = ['S', 'M', 'L', 'XL', 'XXL'];
-  $item->order = array_search($item->size()->value(), $sizes);
-  return $item;
-})->sortBy('order', 'asc');
+$products = $page->products()->structure()->sort(
+  fn ($item) => array_search($item->size()->value(), $sizes),
+  SORT_ASC
+);
 
 dump($products);
 ```
 
-The `map()` method is really useful for all types of scenarios, so keep it in mind for next time you come across a problem that you can't solve with a simple sort.
+Passing a callback function to the `sort()` method is really usefull for all types of scenarios, so keep it in mind for next time you come across a problem that you can't solve with a simple sort.
 
 ## Sorting with Page Models
 

--- a/content/docs/2_cookbook/2_content/0_sorting/cookbook-recipe.txt
+++ b/content/docs/2_cookbook/2_content/0_sorting/cookbook-recipe.txt
@@ -171,7 +171,7 @@ $products = $page->products()->structure()->sort(
 dump($products);
 ```
 
-Passing a callback function to the `sort()` method is really usefull for all types of scenarios, so keep it in mind for next time you come across a problem that you can't solve with a simple sort.
+Passing a callback function to the `sort()` method is really useful for all types of scenarios, so keep it in mind for next time you come across a problem that you can't solve with a simple sort.
 
 ## Sorting with Page Models
 


### PR DESCRIPTION
As [mentioned](https://discord.com/channels/525634039965679616/525641819854471168/1210500537963774012) on the Discord Server, the Sorting Cookbook article currently makes use of _dynamic properties_ that will cause a [deprecation warning in PHP 8.2](https://stitcher.io/blog/deprecated-dynamic-properties-in-php-82). Support for dynamic properties is set to be [removed in PHP 9](https://stitcher.io/blog/new-in-php-82#deprecate-dynamic-properties-rfc).

This pull requests replaces the use of dynamic properties in the article with a callback function. 
I’m not quite sure if this is how the `sort()` method should be used and the guide would require more examples how to change sorting order. 