### PR TITLE
`(tabs…)` KirbyText grouping

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -37,8 +37,9 @@
 @import "site/screencast.css";
 @import "site/search.css";
 @import "site/sidebar.css";
-@import "site/types.css";
+@import "site/tabs.css";
 @import "site/toc.css";
+@import "site/types.css";
 @import "site/voice.css";
 @import "site/with-sidebar.css";
 @import "site/utilities.css";

--- a/assets/css/site/tabs.css
+++ b/assets/css/site/tabs.css
@@ -1,0 +1,33 @@
+.tabs {
+	margin-block: var(--spacing-6);
+	border: 1px solid var(--color-border);
+	border-radius: var(--rounded);
+}
+
+.tabs menu {
+	display: flex;
+}
+
+.tabs menu button {
+	position: relative;
+	padding: var(--spacing-2) var(--spacing-3);
+	font-size: var(--text-xs);
+	overflow: visible;
+}
+
+.tabs menu button[aria-current="true"]::after {
+	position: absolute;
+	content: "";
+	height: 2px;
+	inset-inline: 0;
+	bottom: -1px;
+	background: currentColor;
+}
+
+.tabs menu button:not([aria-current="true"]):hover {
+	opacity: 0.75;
+}
+
+.tabs > div {
+	padding: var(--spacing-6);
+}

--- a/assets/css/site/tabs.css
+++ b/assets/css/site/tabs.css
@@ -4,18 +4,18 @@
 	border-radius: var(--rounded);
 }
 
-.tabs menu {
+.tabs nav {
 	display: flex;
 }
 
-.tabs menu button {
+.tabs nav button {
 	position: relative;
 	padding: var(--spacing-2) var(--spacing-3);
 	font-size: var(--text-xs);
 	overflow: visible;
 }
 
-.tabs menu button[aria-current="true"]::after {
+.tabs nav button[aria-selected="true"]::after {
 	position: absolute;
 	content: "";
 	height: 2px;
@@ -24,7 +24,7 @@
 	background: currentColor;
 }
 
-.tabs menu button:not([aria-current="true"]):hover {
+.tabs nav button:not([aria-selected="true"]):hover {
 	opacity: 0.75;
 }
 

--- a/content/styleguide/text.txt
+++ b/content/styleguide/text.txt
@@ -328,3 +328,82 @@ Before updating your Kirby installation, always create a backup before changing 
 <alert>
 This is really dangerous. Better know what you are doing.
 </alert>
+
+## KirbyText groupings
+
+We've added some custom directives to our custom Parsedown parser Marsdown that allow us to group content in various ways.
+
+## Columns
+
+You can split your content into a two-column grid by wrapping the group with `(columns…)` and `(…columns)`. To separate each column, use `++++` as divider:
+
+```kirbytext
+&lpar;columns…)
+
+Column 1
+
+++++
+
+Column 2
+
+&lpar;…columns)
+```
+
+#### Example
+
+(columns…)
+
+Column 1
+
+++++
+
+Column 2
+
+(…columns)
+
+
+## Tabs
+
+Similarly, you can organize content in tabs by wrapping it in `(tabs)` and `(tabs)`. Each content section that should create its own tab needs to start with `=== ` followed by the tab title:
+
+```kirbytext
+&lpar;tabs…)
+=== Tab title 1
+Tab content 1
+
+=== Tab title 2
+Tab content 2
+
+=== Tab title 3
+Tab content 3
+&lpar;…tabs)
+```
+
+#### Example
+
+(tabs…)
+=== Tab title 1
+Tab content 1
+
+=== Tab title 2
+Tab content 2
+
+=== Tab title 3
+Tab content 3
+(…tabs)
+
+## Since version
+
+To signal that content refers to a specific Kirby version or that the feature was only added in a specific version, wrap the content in a `<since>` tag:
+
+<figure class="code">
+  <pre><code class="language-markdown">&lt;since v="4.0.0"&gt;
+A feature that got added in Kirby 4.0.0
+&lt;/since&gt;</code></pre>
+</figure>
+
+#### Example
+
+<since v="4.0.0">
+A feature that got added in Kirby 4.0.0
+</since>

--- a/site/plugins/site/src/Marsdown/Marsdown.php
+++ b/site/plugins/site/src/Marsdown/Marsdown.php
@@ -105,11 +105,18 @@ class Marsdown extends ParsedownExtra
 			$titles[1]
 		);
 
+		$id = Str::random(3);
+
 		return [
 			'element' => [
 				'name' => 'div',
+				'attributes' => [
+					'class' => 'tabs',
+					'id'    => 'tabs-' . $id
+				],
 				'rawHtml' => snippet('kirbytext/tabs', [
-					'tabs' => $tabs ?? []
+					'id'   => $id,
+					'tabs' => $tabs,
 				], true),
 			]
 		];

--- a/site/snippets/kirbytext/tabs.php
+++ b/site/snippets/kirbytext/tabs.php
@@ -1,25 +1,19 @@
-<?php
-$uuid = Str::uuid();
-?>
-
-<div class="tabs" id="tabs-<?= $uuid ?>">
-	<menu>
-		<?php foreach ($tabs as $key => $tab): ?>
-		<button
-			:aria-current="current === '<?= $key ?>'"
-			@click="current = '<?= $key ?>'"
-		>
-			<?= $tab['title'] ?>
-		</button>
-		<?php endforeach ?>
-	</menu>
-
+<menu>
 	<?php foreach ($tabs as $key => $tab): ?>
-	<div v-show="current === '<?= $key ?>'">
-		<?= $tab['content'] ?>
-	</div>
+	<button
+		:aria-current="current === '<?= $key ?>'"
+		@click="current = '<?= $key ?>'"
+	>
+		<?= $tab['title'] ?>
+	</button>
 	<?php endforeach ?>
+</menu>
+
+<?php foreach ($tabs as $key => $tab): ?>
+<div v-show="current === '<?= $key ?>'">
+	<?= $tab['content'] ?>
 </div>
+<?php endforeach ?>
 
 <script type="module">
 import {
@@ -28,5 +22,5 @@ import {
 
 createApp({
 	current: "<?= array_keys($tabs)[0] ?>",
-}).mount("#tabs-<?= $uuid ?>")
+}).mount("#tabs-<?= $id ?>")
 </script>

--- a/site/snippets/kirbytext/tabs.php
+++ b/site/snippets/kirbytext/tabs.php
@@ -1,16 +1,24 @@
-<menu>
+<nav role="tablist">
 	<?php foreach ($tabs as $key => $tab): ?>
 	<button
-		:aria-current="current === '<?= $key ?>'"
+		:aria-selected="current === '<?= $key ?>'"
+		aria-controls="tabs-<?= $id ?>-<?= $key ?>"
+		id="tabs-<?= $id ?>-<?= $key ?>-label"
+		role="tab"
 		@click="current = '<?= $key ?>'"
 	>
 		<?= $tab['title'] ?>
 	</button>
 	<?php endforeach ?>
-</menu>
+</nav>
 
 <?php foreach ($tabs as $key => $tab): ?>
-<div v-show="current === '<?= $key ?>'">
+<div
+	v-show="current === '<?= $key ?>'"
+	aria-labelledby="tabs-<?= $id ?>-<?= $key ?>-label"
+	id="tabs-<?= $id ?>-<?= $key ?>"
+	role="tabpanel"
+>
 	<?= $tab['content'] ?>
 </div>
 <?php endforeach ?>

--- a/site/snippets/kirbytext/tabs.php
+++ b/site/snippets/kirbytext/tabs.php
@@ -1,0 +1,32 @@
+<?php
+$uuid = Str::uuid();
+?>
+
+<div class="tabs" id="tabs-<?= $uuid ?>">
+	<menu>
+		<?php foreach ($tabs as $key => $tab): ?>
+		<button
+			:aria-current="current === '<?= $key ?>'"
+			@click="current = '<?= $key ?>'"
+		>
+			<?= $tab['title'] ?>
+		</button>
+		<?php endforeach ?>
+	</menu>
+
+	<?php foreach ($tabs as $key => $tab): ?>
+	<div v-show="current === '<?= $key ?>'">
+		<?= $tab['content'] ?>
+	</div>
+	<?php endforeach ?>
+</div>
+
+<script type="module">
+import {
+	createApp
+} from '<?= url('assets/js/libraries/petite-vue.js') ?>';
+
+createApp({
+	current: "<?= array_keys($tabs)[0] ?>",
+}).mount("#tabs-<?= $uuid ?>")
+</script>

--- a/site/templates/guide.php
+++ b/site/templates/guide.php
@@ -10,5 +10,7 @@
 <?php endslot() ?>
 
 <?php slot('prevnext') ?>
-<?php snippet('layouts/prevnext', ['siblings' => page('docs/guide')->index()->listed()]) ?>
+<?php snippet('layouts/prevnext', [
+	'siblings' => page('docs/guide')->index()->listed()
+]) ?>
 <?php endslot() ?>


### PR DESCRIPTION
<img width="874" alt="Screenshot 2024-03-01 at 21 36 17" src="https://github.com/getkirby/getkirby.com/assets/3788865/c6e58eb7-5dc5-4243-bced-7a005cbe570d">

```
(tabs…)
=== Tab title 1
Tab content 1

=== Tab title 2
Tab content 2

=== Tab title 3
Tab content 3
(…tabs)
```

@texnixe I chose not to use it in any actual guide yet as example, because you are working currently on them. So I would leave that to you, where/how to use this best. But added one example in the style guide to show how it works.