### PR TITLE
Add example for language-agnostic routes

### DIFF
--- a/content/docs/1_guide/14_routing/guide.txt
+++ b/content/docs/1_guide/14_routing/guide.txt
@@ -270,6 +270,22 @@ return [
 ];
 ```
 
+If you want your route to match every language, you may use `*` as a placeholder. The langugae code will be passed to the action callback as first argument:
+
+```php
+return [
+    'routes' => [
+        [
+            'pattern' => '(:any)',
+            'language' => '*',
+            'action' => function ($language, $slug) {
+							// The first argument will always be the language code, e.g. 'en'
+            }
+        ],
+    ]
+];
+```
+
 To make sure that translated slugs are automatically handled by Kirby, you can set a page scope:
 
 ```php

--- a/content/docs/1_guide/14_routing/guide.txt
+++ b/content/docs/1_guide/14_routing/guide.txt
@@ -270,21 +270,7 @@ return [
 ];
 ```
 
-If you want your route to match every language, you may use `*` as a placeholder. The langugae code will be passed to the action callback as first argument:
-
-```php
-return [
-    'routes' => [
-        [
-            'pattern' => '(:any)',
-            'language' => '*',
-            'action' => function ($language, $slug) {
-							// The first argument will always be the language code, e.g. 'en'
-            }
-        ],
-    ]
-];
-```
+If you want your route to match every language, you may use `*` as a placeholder instead of a language code. 
 
 To make sure that translated slugs are automatically handled by Kirby, you can set a page scope:
 


### PR DESCRIPTION
This way it is clear that you can use the `*` placeholder without a page context and that the first parameter will always be the language code. 