### PR TITLE
Improve `resources` and add to ToC

### DIFF
--- a/content/docs/1_guide/6_templates/1_basics/guide.txt
+++ b/content/docs/1_guide/6_templates/1_basics/guide.txt
@@ -254,9 +254,12 @@ $kirby->response()->type('text/plain');
 The `$kirby->response()` object provides several other methods to customize the response (e.g. caching, HTTP headers and the HTTP status code). (link: docs/reference/objects/cms/responder text: Learn more in the reference ›)
 </info>
 
-## More information
 
-- (link: docs/cookbook/content-structure/custom-post-types text: Custom post types)
-- (link: docs/cookbook/php/php-templates text: Kirby templates 101)
-- (link: docs/cookbook/php/debugging-basics text: Basic error hunting & prevention)
-- (link: docs/cookbook/content-structure/one-pager text: One-pager site)
+----
+
+Resources:
+
+- docs/cookbook/content-structure/custom-post-types
+- docs/cookbook/php/php-templates
+- docs/cookbook/php/debugging-basics
+- docs/cookbook/content-structure/one-pager

--- a/content/docs/3_cookbook/0_php/0_php-templates/cookbook-recipe.txt
+++ b/content/docs/3_cookbook/0_php/0_php-templates/cookbook-recipe.txt
@@ -2,9 +2,6 @@ Title: PHP templating
 
 ----
 
-
-----
-
 Description: Learn some PHP basics that make creating templates a breeze.
 
 ----

--- a/site/controllers/guide.php
+++ b/site/controllers/guide.php
@@ -22,7 +22,6 @@ return function (Page $page) {
 	return [
 		'guide'     => $page,
 		'menu'      => $menu,
-		'resources' => $page->resources()->toPages(),
 		'prevnext'  => $prevnext->filterBy('isChapter', false)
 	];
 };

--- a/site/layouts/article.php
+++ b/site/layouts/article.php
@@ -54,6 +54,8 @@
 
 					<?php if ($resources = $slots->resources()): ?>
 						<?= $resources ?>
+					<?php elseif ($resources = $page->resources()->toPages()): ?>
+						<?php snippet('resources', ['resources' => $resources]) ?>
 					<?php endif ?>
 
 					<?php if ($prevnext = $slots->prevnext()): ?>

--- a/site/snippets/resources.php
+++ b/site/snippets/resources.php
@@ -5,12 +5,12 @@
 			More information
 		</h2>
 	<?php endif ?>
-	<ul>
+	<ul class="columns" style="--columns: 2; --columns-md: 1; gap: var(--spacing-1); grid-auto-rows: auto">
 		<?php foreach ($resources as $resource): ?>
-		<li class="mb-3 bg-light rounded p-3">
+		<li class="bg-light rounded p-6">
 			<a href="<?= $resource->url() ?>">
-				<h3 class="h4"><?= $resource->title() ?></h3>
-				<p class="color-gray-700"><?= $resource->description() ?></p>
+				<h3 class="font-bold link"><?= $resource->title() ?></h3>
+				<p class="color-gray-700 text-sm"><?= $resource->description() ?></p>
 			</a>
 		</li>
 		<?php endforeach ?>

--- a/site/snippets/resources.php
+++ b/site/snippets/resources.php
@@ -1,0 +1,19 @@
+<?php if ($resources->count() > 0): ?>
+<aside class="mb-24">
+	<?php if ($page->text()->isNotEmpty()): ?>
+		<h2 class="h2 mb-6" id="resources">
+			More information
+		</h2>
+	<?php endif ?>
+	<ul>
+		<?php foreach ($resources as $resource): ?>
+		<li class="mb-3 bg-light rounded p-3">
+			<a href="<?= $resource->url() ?>">
+				<h3 class="h4"><?= $resource->title() ?></h3>
+				<p class="color-gray-700"><?= $resource->description() ?></p>
+			</a>
+		</li>
+		<?php endforeach ?>
+	</ul>
+</aside>
+<?php endif ?>

--- a/site/snippets/toc.php
+++ b/site/snippets/toc.php
@@ -1,12 +1,20 @@
-<?php $items = $page->text()->toToc($tag ?? 'h2') ?>
+<?php
+$items        = $page->text()->toToc($tag ?? 'h2');
+$hasResources = $page->resources()->isNotEmpty();
+$limit        = $hasResources ? 1 : 2;
+?>
 
-<?php if($items->count() > 2): ?>
+<?php if($items->count() > $limit): ?>
 <nav aria-labelledby="toc-heading" class="toc">
 	<h2 id="toc-heading" class="badge"><?= $title ?? 'On this page' ?></h2>
 	<ol class="pt-3">
 		<?php foreach($items as $item): ?>
 		<li><a href="<?= $item->id() ?>"><?= widont($item->text()) ?></a></li>
 		<?php endforeach ?>
+
+		<?php if($hasResources): ?>
+			<li><a href="#resources">More information</a></li>
+		<?php endif ?>
 	</ol>
 </nav>
 <?php endif ?>

--- a/site/templates/guide.php
+++ b/site/templates/guide.php
@@ -9,26 +9,6 @@
 ]) ?>
 <?php endslot() ?>
 
-<?php slot('resources') ?>
-<?php if ($resources->count() > 0): ?>
-<aside class="mb-24">
-	<?php if ($page->text()->isNotEmpty()): ?>
-		<h2 class="h2 mb-6">Additional resources</h2>
-	<?php endif ?>
-	<ul>
-		<?php foreach ($resources as $resource): ?>
-		<li class="mb-3 bg-light rounded p-3">
-			<a href="<?= $resource->url() ?>">
-				<h3 class="h4"><?= $resource->title() ?></h3>
-				<p class="color-gray-700"><?= $resource->description() ?></p>
-			</a>
-		</li>
-		<?php endforeach ?>
-	</ul>
-</aside>
-<?php endif ?>
-<?php endslot() ?>
-
 <?php slot('prevnext') ?>
 <?php snippet('layouts/prevnext', ['siblings' => $prevnext]) ?>
 <?php endslot() ?>


### PR DESCRIPTION
Better universal handling of `resources` field as "More information" section in articles, incl. support that this section gets included in the table of content.

Added one guide example: Rendering & logic > Templates