### PR TITLE
Add missing URL for paid plugins from `johannschopplich`

### DIFF
--- a/content/plugins/johannschopplich/copilot/plugin.txt
+++ b/content/plugins/johannschopplich/copilot/plugin.txt
@@ -26,6 +26,10 @@ Repository: https://github.com/johannschopplich/kirby-copilot
 
 ----
 
+Paid: https://kirbycopilot.com/buy
+
+----
+
 Category: panel
 
 ----

--- a/content/plugins/johannschopplich/seo-audit/plugin.txt
+++ b/content/plugins/johannschopplich/seo-audit/plugin.txt
@@ -25,6 +25,10 @@ Repository: https://github.com/johannschopplich/kirby-seo-audit
 
 ----
 
+Paid: https://kirbyseo.com/buy
+
+----
+
 Category: seo
 
 ----


### PR DESCRIPTION
I completely forgot to add the corresponding buy page URLs.