### PR TITLE
Update paid plugins data (again)

### DIFF
--- a/content/plugins/johannschopplich/copilot/plugin.txt
+++ b/content/plugins/johannschopplich/copilot/plugin.txt
@@ -22,10 +22,6 @@ Documentation: https://kirbycopilot.com
 
 ----
 
-Repository: https://github.com/johannschopplich/kirby-copilot
-
-----
-
 Paid: https://kirbycopilot.com/buy
 
 ----

--- a/content/plugins/johannschopplich/seo-audit/plugin.txt
+++ b/content/plugins/johannschopplich/seo-audit/plugin.txt
@@ -21,10 +21,6 @@ Documentation: https://kirbyseo.com
 
 ----
 
-Repository: https://github.com/johannschopplich/kirby-seo-audit
-
-----
-
 Paid: https://kirbyseo.com/buy
 
 ----


### PR DESCRIPTION
Both paid plugins from me are closed source. The only open source part is the website. Thus, it's better to remove the GitHub link to prevent users from getting confused.