### PR TITLE
Update link to public folder guide in ddev cookbook

### DIFF
--- a/content/docs/3_cookbook/0_development-deployment/0_ddev/cookbook-recipe.txt
+++ b/content/docs/3_cookbook/0_development-deployment/0_ddev/cookbook-recipe.txt
@@ -112,7 +112,7 @@ Running the `ddev composer create` command will delete everything in the current
 
 === Public folder setup
 
-When possible, we recommend a (link: docs/guide/configuration#custom-folder-setup__public-and-private-folder-setup text: public folder setup) to move all files that need not be publicly accessible out of the doc root for enhanced security.
+When possible, we recommend a (link: docs/guide/configuration/custom-folder-setup#public-and-private-folder-setup text: public folder setup) to move all files that need not be publicly accessible out of the doc root for enhanced security.
 
 If you already have a public folder set the `docroot` flag to the name of your public folder, e.g. `public`:
 
@@ -127,7 +127,7 @@ If you don't have a public folder setup yet, run:
 ddev config --docroot=public --create-docroot && ddev restart
 ```
 
-This command will create a new `public` folder. Then move all your assets, and the `index.php` into the `public` folder. Modify the `index.php` as described in our (link: docs/guide/configuration#custom-folder-setup__public-and-private-folder-setup text: public folder documentation).
+This command will create a new `public` folder. Then move all your assets, and the `index.php` into the `public` folder. Modify the `index.php` as described in our (link: docs/guide/configuration/custom-folder-setup#public-and-private-folder-setup text: public folder documentation).
 
 (…tabs)
 


### PR DESCRIPTION
The link to the guide regarding the public and private folder setup was outdated.