### PR TITLE
Update cookbook-recipe.txt

### DIFF
--- a/content/docs/3_cookbook/0_panel/0_first-panel-area/cookbook-recipe.txt
+++ b/content/docs/3_cookbook/0_panel/0_first-panel-area/cookbook-recipe.txt
@@ -32,7 +32,7 @@ For the purposes of this recipe, we assume you have read the (link: docs/guide/p
 You can install the (link: https://github.com/getkirby/pluginkit/tree/4-panel text: Pluginkit) as a basis or create the file structure we need manually, that's up to you. Also, it doesn't matter if you use the Plainkit or the Starterkit as a starting point.
 </info>
 
-Let's start by creating a new folder in the `plugins folder, which we will call `moviereviews`. Inside this folder, we first create a `package.json` file with the contents copied from the Pluginkit example mentioned above.
+Let's start by creating a new folder in the `plugins` folder, which we will call `moviereviews`. Inside this folder, we first create a `package.json` file with the contents copied from the Pluginkit example mentioned above.
 
 ```js "/site/plugins/moviereviews/package.json"
 {


### PR DESCRIPTION
Just a quick fix for a missing backtick that caused confusing formatting:

![image](https://github.com/getkirby/getkirby.com/assets/5441654/25c02cf2-10f8-4f1e-b1b6-08c864701fde)

Thank you for this awesome CMS!