### PR TITLE
Update cookbook-recipe.txt

### DIFF
--- a/content/docs/3_cookbook/0_extensions/0_create-pdf-preview-images/cookbook-recipe.txt
+++ b/content/docs/3_cookbook/0_extensions/0_create-pdf-preview-images/cookbook-recipe.txt
@@ -300,7 +300,7 @@ Kirby::plugin('cookbook/pdfpreview', [
             $options['page'] ??= 0;
             $extension   = $options['format'] ?? 'jpg';
             $previewName = $this->name() . '.' . $extension;
-            $outputPath  = $this->root() . '.' . $extension;
+            $outputPath  = Str::replace($this->root(), '.pdf', '.' . $extension);
             // only create the file if `$force` is set to true or
             // it doesn't exist yet or the PDF file is newer than the preview image
             if ($force === true || !F::exists($outputPath) || (F::modified($outputPath) < $this->modified())) {


### PR DESCRIPTION
$this->root() contains the full file name with the original extension.
The extension must be replaced and not concatenated, otherwise the preview file will not be found and will always be regenerated.