### PR TITLE
Class methods: use docblock description for example code

### DIFF
--- a/content/docs/2_reference/4_objects/cms/0_app/0_collection/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_app/0_collection/reference-classmethod.txt
@@ -1,9 +1,8 @@
 Guide: templates/collections
 
 ----
-Text:
 
-## Example
+Example:
 
 Call a predefined collection by key:
 

--- a/content/docs/2_reference/4_objects/cms/0_app/0_controller/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_app/0_controller/reference-classmethod.txt
@@ -1,5 +1,3 @@
-Text:
-
-## Example
+Example:
 
 See (link: docs/cookbook/development-deployment/shared-controllers#setting-up-the-shared-controller text: Shared controllers)

--- a/content/docs/2_reference/4_objects/cms/0_app/0_email/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_app/0_email/reference-classmethod.txt
@@ -2,9 +2,7 @@ Guide: emails
 
 ----
 
-Text:
-
-## Examples
+Example:s
 
 ## Basic example
 

--- a/content/docs/2_reference/4_objects/cms/0_app/0_native-component/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_app/0_native-component/reference-classmethod.txt
@@ -1,5 +1,3 @@
-Text:
-
-## Example
+Example:
 
 See (link:docs/cookbook/performance/kirby-loves-cdn text: Kirby loves CDN)

--- a/content/docs/2_reference/4_objects/cms/0_app/0_nonce/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_app/0_nonce/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text:
-
-## Example
+Example:
 
 The method generates a nonce that you can use in your inline scripts in conjuction with the Content Security Policy of your website.
 

--- a/content/docs/2_reference/4_objects/cms/0_app/0_page/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_app/0_page/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text:
-
-## Example
+Example:
 
 ```php
 <?php

--- a/content/docs/2_reference/4_objects/cms/0_blocks/0_add/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_blocks/0_add/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text:
-
-## Example
+Example:
 
 ```php
 $blocks = new \Kirby\Cms\Blocks();

--- a/content/docs/2_reference/4_objects/cms/0_blocks/0_factory/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_blocks/0_factory/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text:
-
-## Example
+Example:
 
 ```php
 <?php

--- a/content/docs/2_reference/4_objects/cms/0_blocks/0_filter-by/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_blocks/0_filter-by/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text:
-
-## Example
+Example:
 
 Filter blocks by attribute, e.g. type:
 

--- a/content/docs/2_reference/4_objects/cms/0_blocks/0_filter/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_blocks/0_filter/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text:
-
-## Example
+Example:
 
 ```php
 $blocks = $page->text()->toBlocks()->filter(fn ($block) => $block->hasMethod('customMethod'));

--- a/content/docs/2_reference/4_objects/cms/0_blocks/0_find-by/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_blocks/0_find-by/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text:
-
-## Example
+Example:
 
 Find blocks by attribute, e.g. type:
 

--- a/content/docs/2_reference/4_objects/cms/0_blocks/0_has-type/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_blocks/0_has-type/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text:
-
-## Example
+Example:
 
 Useful if you want to include scripts etc. depending on block types.
 

--- a/content/docs/2_reference/4_objects/cms/0_blocks/0_has/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_blocks/0_has/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text:
-
-## Example
+Example:
 
 Check if a block exists
 

--- a/content/docs/2_reference/4_objects/cms/0_blocks/0_when/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_blocks/0_when/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text:
-
-## Example
+Example:
 
 Filter by type if type is given:
 

--- a/content/docs/2_reference/4_objects/cms/0_collection/0_group/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_collection/0_group/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text:
-
-## Example
+Example:
 
 ```php
 <!-- group the collection by the field `category` -->

--- a/content/docs/2_reference/4_objects/cms/0_file/0_blur/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_file/0_blur/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 if($image = $page->image()):
@@ -8,9 +6,7 @@ if($image = $page->image()):
 endif;
 ```
 
-
-
-## Blur Amount
+### Blur Amount
 
 You can modify the strength of the blur effect by passing an integer. The default value is 10.
 

--- a/content/docs/2_reference/4_objects/cms/0_file/0_bw/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_file/0_bw/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 if($image = $page->image()):

--- a/content/docs/2_reference/4_objects/cms/0_file/0_crop/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_file/0_crop/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text:
-
-## Example
+Example:
 
 ```php
 if($image = $page->image()):

--- a/content/docs/2_reference/4_objects/cms/0_file/0_delete/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_file/0_delete/reference-classmethod.txt
@@ -2,9 +2,7 @@ Auth: files.delete
 
 ----
 
-Text:
-
-## Example
+Example:
 
 ```php
 if($file = $page->file('old-file.pdf')) {

--- a/content/docs/2_reference/4_objects/cms/0_file/0_filename/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_file/0_filename/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 if($file = $page->file()) {

--- a/content/docs/2_reference/4_objects/cms/0_file/0_files/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_file/0_files/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 if($file = $page->files()->first()) {

--- a/content/docs/2_reference/4_objects/cms/0_file/0_has-next/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_file/0_has-next/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 $file = $page->file('myfile.pdf');

--- a/content/docs/2_reference/4_objects/cms/0_file/0_has-prev/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_file/0_has-prev/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 $file = $page->file('myfile.pdf');

--- a/content/docs/2_reference/4_objects/cms/0_file/0_kirby/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_file/0_kirby/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 $kirby = $file->kirby();

--- a/content/docs/2_reference/4_objects/cms/0_file/0_modified/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_file/0_modified/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text:
-
-## Example
+Example:
 
 ```php
 

--- a/content/docs/2_reference/4_objects/cms/0_file/0_next/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_file/0_next/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 if(($file = $page->file('my-file.pdf')) && $next = $file->next()):

--- a/content/docs/2_reference/4_objects/cms/0_file/0_page/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_file/0_page/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 echo 'Document of: ' . $file->page()->title();

--- a/content/docs/2_reference/4_objects/cms/0_file/0_prev/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_file/0_prev/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 if(($file = $page->file('my-file.pdf')) && $prev = $file->prev()):

--- a/content/docs/2_reference/4_objects/cms/0_file/0_resize/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_file/0_resize/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 if($image = $page->image()):

--- a/content/docs/2_reference/4_objects/cms/0_file/0_root/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_file/0_root/reference-classmethod.txt
@@ -1,10 +1,8 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 if($file = $page->file()):
     echo $file->root();
     // i.e. /var/www/yourdomain.com/html/content/some-page/some-file.jpg
-endif;    
+endif;
 ```

--- a/content/docs/2_reference/4_objects/cms/0_file/0_siblings/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_file/0_siblings/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 if($file = $page->file()) {

--- a/content/docs/2_reference/4_objects/cms/0_file/0_site/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_file/0_site/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 $site = $file->site();

--- a/content/docs/2_reference/4_objects/cms/0_file/0_srcset/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_file/0_srcset/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text:
-
-## Example
+Example:
 
 ```php
 <img

--- a/content/docs/2_reference/4_objects/cms/0_file/0_to-array/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_file/0_to-array/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 if($image = $page->image()):

--- a/content/docs/2_reference/4_objects/cms/0_file/0_type/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_file/0_type/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text:
-
-## Example
+Example:
 
 ```php
 if($file = $page->file('myimage.jpg')):

--- a/content/docs/2_reference/4_objects/cms/0_file/0_update/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_file/0_update/reference-classmethod.txt
@@ -2,9 +2,7 @@ Auth: files.update
 
 ----
 
-Text:
-
-## Example
+Example:
 
 (docs: immutable-objects)
 

--- a/content/docs/2_reference/4_objects/cms/0_file/0_url/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_file/0_url/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 if($file = $page->file('myimage.jpg')) {

--- a/content/docs/2_reference/4_objects/cms/0_files/0_count/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_files/0_count/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 echo $page->files()->count();

--- a/content/docs/2_reference/4_objects/cms/0_files/0_filter/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_files/0_filter/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text:
-
-## Example
+Example:
 
 ```php
 // fetch files with a caption

--- a/content/docs/2_reference/4_objects/cms/0_files/0_find-by/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_files/0_find-by/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 

--- a/content/docs/2_reference/4_objects/cms/0_files/0_find/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_files/0_find/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ### Fetch a single file
 

--- a/content/docs/2_reference/4_objects/cms/0_files/0_first/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_files/0_first/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?php if($file = $page->files()->first()) {

--- a/content/docs/2_reference/4_objects/cms/0_files/0_flip/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_files/0_flip/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <ul>

--- a/content/docs/2_reference/4_objects/cms/0_files/0_get/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_files/0_get/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?php

--- a/content/docs/2_reference/4_objects/cms/0_files/0_intersection/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_files/0_intersection/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text:
-
-## Example
+Example:
 
 ```php
 $images1 = $page->files()->template('cover');

--- a/content/docs/2_reference/4_objects/cms/0_files/0_intersects/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_files/0_intersects/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text:
-
-## Example
+Example:
 
 ```php
 $images1 = $page->files()->template('cover');

--- a/content/docs/2_reference/4_objects/cms/0_files/0_keys/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_files/0_keys/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ### Example Files
 

--- a/content/docs/2_reference/4_objects/cms/0_files/0_last/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_files/0_last/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?= $page->files()->last()->filename() ?>

--- a/content/docs/2_reference/4_objects/cms/0_files/0_limit/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_files/0_limit/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <ul>

--- a/content/docs/2_reference/4_objects/cms/0_files/0_not/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_files/0_not/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text:
-
-## Example
+Example:
 
 ```php
 <ul>

--- a/content/docs/2_reference/4_objects/cms/0_files/0_nth/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_files/0_nth/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?= $page->files()->nth(3)->filename() ?>

--- a/content/docs/2_reference/4_objects/cms/0_files/0_offset/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_files/0_offset/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <ul>

--- a/content/docs/2_reference/4_objects/cms/0_files/0_paginate/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_files/0_paginate/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 $files      = $page->files()->paginate(10);

--- a/content/docs/2_reference/4_objects/cms/0_files/0_pagination/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_files/0_pagination/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 $files      = $page->files()->paginate(10);

--- a/content/docs/2_reference/4_objects/cms/0_files/0_pluck/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_files/0_pluck/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <ul>

--- a/content/docs/2_reference/4_objects/cms/0_files/0_shuffle/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_files/0_shuffle/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <ul>

--- a/content/docs/2_reference/4_objects/cms/0_files/0_slice/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_files/0_slice/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <ul>

--- a/content/docs/2_reference/4_objects/cms/0_language/0_code/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_language/0_code/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <ul>

--- a/content/docs/2_reference/4_objects/cms/0_language/0_locale/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_language/0_locale/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?= $kirby->language('en')->locale(LC_ALL) ?>

--- a/content/docs/2_reference/4_objects/cms/0_language/0_name/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_language/0_name/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <ul>

--- a/content/docs/2_reference/4_objects/cms/0_language/0_url/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_language/0_url/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?= $site->language('en')->url() ?>

--- a/content/docs/2_reference/4_objects/cms/0_layouts/0_has-block-type/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_layouts/0_has-block-type/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text:
-
-## Example
+Example:
 
 Useful if you want to include scripts etc. depending on block types in layout field.
 

--- a/content/docs/2_reference/4_objects/cms/0_layouts/0_to-blocks/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_layouts/0_to-blocks/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text:
-
-## Example
+Example:
 
 The method makes it easy to filter blocks from layouts:
 

--- a/content/docs/2_reference/4_objects/cms/0_page/0_audio/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_audio/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <h2>Songs</h2>
@@ -13,7 +11,7 @@ Text:
 
 ## What is an audio file?
 
-Kirby considers the following file types as audio files: 
+Kirby considers the following file types as audio files:
 
 - mp3
 - m4a

--- a/content/docs/2_reference/4_objects/cms/0_page/0_change-sort/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_change-sort/reference-classmethod.txt
@@ -2,9 +2,7 @@ Auth: pages.sort
 
 ----
 
-Text:
-
-## Example
+Example:
 
 ```php
 try {

--- a/content/docs/2_reference/4_objects/cms/0_page/0_children/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_children/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <h2>Subpages</h2>

--- a/content/docs/2_reference/4_objects/cms/0_page/0_code/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_code/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?php foreach($page->code()->filterBy('extension', 'css') as $css): ?>
@@ -10,7 +8,7 @@ Text:
 
 ## What is a code file?
 
-Kirby considers the following file types as code: 
+Kirby considers the following file types as code:
 
 - js
 - css

--- a/content/docs/2_reference/4_objects/cms/0_page/0_create-file/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_create-file/reference-classmethod.txt
@@ -5,9 +5,7 @@ Auth: files.create
 Properties: $props|Kirby\Cms\File
 
 ----
-Text:
-
-## Example
+Example:
 
 ### Create new file from a local file path
 

--- a/content/docs/2_reference/4_objects/cms/0_page/0_create/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_create/reference-classmethod.txt
@@ -6,9 +6,7 @@ Properties: $props
 
 ----
 
-Text:
-
-## Example
+Example:
 
 ```php
 $page = Page::create([

--- a/content/docs/2_reference/4_objects/cms/0_page/0_decrement/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_decrement/reference-classmethod.txt
@@ -2,9 +2,7 @@ Auth: pages.update
 
 ----
 
-Text:
-
-## Example
+Example:
 
 (docs: immutable-objects)
 

--- a/content/docs/2_reference/4_objects/cms/0_page/0_delete/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_delete/reference-classmethod.txt
@@ -2,9 +2,7 @@ Auth: pages.delete
 
 ----
 
-Text:
-
-## Example
+Example:
 
 ```php
 try {

--- a/content/docs/2_reference/4_objects/cms/0_page/0_depth/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_depth/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <select onchange="window.location.href = this.value">

--- a/content/docs/2_reference/4_objects/cms/0_page/0_dirname/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_dirname/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?= $page->dirname() ?>

--- a/content/docs/2_reference/4_objects/cms/0_page/0_diruri/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_diruri/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?= $page->diruri() ?>

--- a/content/docs/2_reference/4_objects/cms/0_page/0_documents/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_documents/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <h2>Available PDFs</h2>

--- a/content/docs/2_reference/4_objects/cms/0_page/0_factory/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_factory/reference-classmethod.txt
@@ -1,9 +1,7 @@
 Properties: $props
 
 ----
-Text:
-
-## Example
+Example:
 
 ```php
 $pageObject = Page::factory([

--- a/content/docs/2_reference/4_objects/cms/0_page/0_file/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_file/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ### Fetching the first file
 

--- a/content/docs/2_reference/4_objects/cms/0_page/0_files/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_files/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <h2>Files</h2>

--- a/content/docs/2_reference/4_objects/cms/0_page/0_find/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_find/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ### Fetch a single subpage
 

--- a/content/docs/2_reference/4_objects/cms/0_page/0_go/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_go/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text:
-
-## Example
+Example:
 
 ### Redirect to another page
 

--- a/content/docs/2_reference/4_objects/cms/0_page/0_grand-children/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_grand-children/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example structure
+Example: structure
 
 - blog
     - 2012

--- a/content/docs/2_reference/4_objects/cms/0_page/0_has-audio/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_has-audio/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?php
@@ -14,7 +12,7 @@ if($page->hasAudio()) {
 
 ## What is an audio file?
 
-Kirby considers the following file types as audio files: 
+Kirby considers the following file types as audio files:
 
 - mp3
 - m4a

--- a/content/docs/2_reference/4_objects/cms/0_page/0_has-children/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_has-children/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?php

--- a/content/docs/2_reference/4_objects/cms/0_page/0_has-code/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_has-code/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?php
@@ -14,7 +12,7 @@ if($page->hasCode()) {
 
 ## What is a code file?
 
-Kirby considers the following file types as code: 
+Kirby considers the following file types as code:
 
 - js
 - css

--- a/content/docs/2_reference/4_objects/cms/0_page/0_has-documents/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_has-documents/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?php

--- a/content/docs/2_reference/4_objects/cms/0_page/0_has-files/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_has-files/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?php

--- a/content/docs/2_reference/4_objects/cms/0_page/0_has-images/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_has-images/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?php

--- a/content/docs/2_reference/4_objects/cms/0_page/0_has-listed-children/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_has-listed-children/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 echo $page->hasListedChildren(); //will echo 1 if true, nothing if false

--- a/content/docs/2_reference/4_objects/cms/0_page/0_has-next-listed/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_has-next-listed/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?php

--- a/content/docs/2_reference/4_objects/cms/0_page/0_has-next-unlisted/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_has-next-unlisted/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 if ($page->hasNextUnlisted()) {

--- a/content/docs/2_reference/4_objects/cms/0_page/0_has-next/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_has-next/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?php

--- a/content/docs/2_reference/4_objects/cms/0_page/0_has-prev-listed/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_has-prev-listed/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 if ($page->hasPrevListed()) {

--- a/content/docs/2_reference/4_objects/cms/0_page/0_has-prev-unlisted/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_has-prev-unlisted/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?php

--- a/content/docs/2_reference/4_objects/cms/0_page/0_has-prev/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_has-prev/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?php

--- a/content/docs/2_reference/4_objects/cms/0_page/0_has-unlisted-children/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_has-unlisted-children/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 echo $page->hasUnlistedChildren(); //will echo 1 if true, nothing if false

--- a/content/docs/2_reference/4_objects/cms/0_page/0_has-videos/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_has-videos/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?php

--- a/content/docs/2_reference/4_objects/cms/0_page/0_id/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_id/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?= $page->id() ?>

--- a/content/docs/2_reference/4_objects/cms/0_page/0_image/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_image/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text:
-
-## Example
+Example:
 
 ### Fetching the first image
 

--- a/content/docs/2_reference/4_objects/cms/0_page/0_images/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_images/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <section class="gallery">

--- a/content/docs/2_reference/4_objects/cms/0_page/0_increment/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_increment/reference-classmethod.txt
@@ -2,9 +2,7 @@ Auth: pages.update
 
 ----
 
-Text:
-
-## Example
+Example:
 
 (docs: immutable-objects)
 

--- a/content/docs/2_reference/4_objects/cms/0_page/0_index-of/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_index-of/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text:
-
-## Example
+Example:
 
 ```php
 <?php $children = $page->children()->listed(); ?>

--- a/content/docs/2_reference/4_objects/cms/0_page/0_index/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_index/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 // goes through any subpage, subsubpage, etc. below $page and returns them by template

--- a/content/docs/2_reference/4_objects/cms/0_page/0_is-active/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_is-active/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <nav role="navigation">

--- a/content/docs/2_reference/4_objects/cms/0_page/0_is-ancestor-of/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_is-ancestor-of/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?php if($page->isAncestorOf('some-child-page')): ?>

--- a/content/docs/2_reference/4_objects/cms/0_page/0_is-child-of/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_is-child-of/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?php if($page->isChildOf('some-parent-page')): ?>

--- a/content/docs/2_reference/4_objects/cms/0_page/0_is-descendant-of-active/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_is-descendant-of-active/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?php if($page->isDescendantOfActive()): ?>

--- a/content/docs/2_reference/4_objects/cms/0_page/0_is-descendant-of/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_is-descendant-of/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?php if($page->isDescendantOf('some-page')): ?>

--- a/content/docs/2_reference/4_objects/cms/0_page/0_is-error-page/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_is-error-page/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ### A custom css file for the error page
 

--- a/content/docs/2_reference/4_objects/cms/0_page/0_is-home-page/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_is-home-page/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ### A custom title for the homepage
 

--- a/content/docs/2_reference/4_objects/cms/0_page/0_is-open/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_is-open/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <nav role="navigation">

--- a/content/docs/2_reference/4_objects/cms/0_page/0_is/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_is/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text:
-
-## Example
+Example:
 
 Filter all articles for the current author page:
 

--- a/content/docs/2_reference/4_objects/cms/0_page/0_modified/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_modified/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 Last update: <?= $page->modified('d/m/Y H:i') ?>

--- a/content/docs/2_reference/4_objects/cms/0_page/0_next-listed/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_next-listed/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?php if($next = $page->nextListed()): ?>

--- a/content/docs/2_reference/4_objects/cms/0_page/0_next-unlisted/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_next-unlisted/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?php if($next = $page->nextUnlisted()): ?>

--- a/content/docs/2_reference/4_objects/cms/0_page/0_next/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_next/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?php if($next = $page->next()): ?>

--- a/content/docs/2_reference/4_objects/cms/0_page/0_num/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_num/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?= $page->num() ?>

--- a/content/docs/2_reference/4_objects/cms/0_page/0_parent/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_parent/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 This page is a subpage of:

--- a/content/docs/2_reference/4_objects/cms/0_page/0_parents/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_parents/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?php

--- a/content/docs/2_reference/4_objects/cms/0_page/0_prev-listed/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_prev-listed/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?php if($prev = $page->prevListed()): ?>

--- a/content/docs/2_reference/4_objects/cms/0_page/0_prev-unlisted/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_prev-unlisted/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?php if($prev = $page->prevUnlisted()): ?>

--- a/content/docs/2_reference/4_objects/cms/0_page/0_prev/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_prev/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?php if($prev = $page->prev()): ?>

--- a/content/docs/2_reference/4_objects/cms/0_page/0_query/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_query/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 This example will return a pages collection when the page has children:
 

--- a/content/docs/2_reference/4_objects/cms/0_page/0_root/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_root/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?= $page->root() ?>

--- a/content/docs/2_reference/4_objects/cms/0_page/0_search/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_search/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 // search the entire site

--- a/content/docs/2_reference/4_objects/cms/0_page/0_siblings/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_siblings/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?php

--- a/content/docs/2_reference/4_objects/cms/0_page/0_slug/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_slug/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?= $page->slug() ?>

--- a/content/docs/2_reference/4_objects/cms/0_page/0_template/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_template/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?= $page->template() ?>

--- a/content/docs/2_reference/4_objects/cms/0_page/0_title/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_title/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?= $page->title() ?>

--- a/content/docs/2_reference/4_objects/cms/0_page/0_to-array/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_to-array/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?php

--- a/content/docs/2_reference/4_objects/cms/0_page/0_uid/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_uid/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?= $page->uid() ?>

--- a/content/docs/2_reference/4_objects/cms/0_page/0_update/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_update/reference-classmethod.txt
@@ -2,9 +2,7 @@ Auth: pages.update
 
 ----
 
-Text:
-
-## Example
+Example:
 
 (docs: immutable-objects)
 

--- a/content/docs/2_reference/4_objects/cms/0_page/0_uri/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_uri/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?= $page->uri() ?>

--- a/content/docs/2_reference/4_objects/cms/0_page/0_url/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_url/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?= $page->url() ?>

--- a/content/docs/2_reference/4_objects/cms/0_page/0_videos/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_videos/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <h2>Videos</h2>

--- a/content/docs/2_reference/4_objects/cms/0_pages/0_add/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_pages/0_add/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text:
-
-## Examples
+Example:s
 
 ### Add single page by ID
 

--- a/content/docs/2_reference/4_objects/cms/0_pages/0_append/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_pages/0_append/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 $collection = page('projects')->children()->limit(1);

--- a/content/docs/2_reference/4_objects/cms/0_pages/0_children/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_pages/0_children/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ### Fetch the children of all pages in the collection
 

--- a/content/docs/2_reference/4_objects/cms/0_pages/0_chunk/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_pages/0_chunk/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text:
-
-## Example
+Example:
 
 E.g. create chunks of three items per chunk:
 

--- a/content/docs/2_reference/4_objects/cms/0_pages/0_count/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_pages/0_count/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ### Counting first level pages
 

--- a/content/docs/2_reference/4_objects/cms/0_pages/0_files/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_pages/0_files/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Examples
+Example:s
 
 ```php
 <?php foreach($pages->files() as $file) : ?>

--- a/content/docs/2_reference/4_objects/cms/0_pages/0_filter-by/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_pages/0_filter-by/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text:
-
-## Example
+Example:
 
 ```php
 // fetch children with a field 'draft', which has the value 'yes'

--- a/content/docs/2_reference/4_objects/cms/0_pages/0_filter/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_pages/0_filter/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text:
-
-## Example
+Example:
 
 ```php
 // fetch children with a title starting with 'Project'

--- a/content/docs/2_reference/4_objects/cms/0_pages/0_find-by/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_pages/0_find-by/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?= $page->children()->findBy('uid', 'some-page')->title() ?>

--- a/content/docs/2_reference/4_objects/cms/0_pages/0_find-open/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_pages/0_find-open/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?= $page->children()->findOpen()->title() ?>

--- a/content/docs/2_reference/4_objects/cms/0_pages/0_find/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_pages/0_find/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ### Fetch a single subpage
 

--- a/content/docs/2_reference/4_objects/cms/0_pages/0_first/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_pages/0_first/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?= $page->children()->first()->title() ?>

--- a/content/docs/2_reference/4_objects/cms/0_pages/0_flip/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_pages/0_flip/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?php $articles = $page->children()->flip() ?>

--- a/content/docs/2_reference/4_objects/cms/0_pages/0_get/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_pages/0_get/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?= $page->children()->get('some-page')->title() ?>

--- a/content/docs/2_reference/4_objects/cms/0_pages/0_group-by/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_pages/0_group-by/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text:
-
-## Example:
+Example::
 
 ```php
 <?php

--- a/content/docs/2_reference/4_objects/cms/0_pages/0_group/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_pages/0_group/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text:
-
-## Example
+Example:
 
 ```php
 // return collection of pages grouped by the first character of their title field

--- a/content/docs/2_reference/4_objects/cms/0_pages/0_intersection/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_pages/0_intersection/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text:
-
-## Example
+Example:
 
 ```php
 $articles1 = $page->children()->filterBy('tags', 'water', ',');

--- a/content/docs/2_reference/4_objects/cms/0_pages/0_intersects/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_pages/0_intersects/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text:
-
-## Example
+Example:
 
 ```php
 $articles1 = $page->children()->filterBy('tags', 'water', ',');

--- a/content/docs/2_reference/4_objects/cms/0_pages/0_keys/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_pages/0_keys/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ### Example pages
 

--- a/content/docs/2_reference/4_objects/cms/0_pages/0_last/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_pages/0_last/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?= $page->children()->last()->title() ?>

--- a/content/docs/2_reference/4_objects/cms/0_pages/0_limit/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_pages/0_limit/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <h2>Latest subpages</h2>

--- a/content/docs/2_reference/4_objects/cms/0_pages/0_map/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_pages/0_map/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 function changeDate($page)  {

--- a/content/docs/2_reference/4_objects/cms/0_pages/0_merge/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_pages/0_merge/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example:
+Example::
 
 
 ```php

--- a/content/docs/2_reference/4_objects/cms/0_pages/0_not-template/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_pages/0_not-template/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text:
-
-## Examples
+Example:s
 
 ### Using a string parameter to exclude a single template:
 

--- a/content/docs/2_reference/4_objects/cms/0_pages/0_not/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_pages/0_not/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text:
-
-## Example
+Example:
 
 Note that you have to pass the full [`id`](/docs/reference/objects/page/id) as parameter:
 

--- a/content/docs/2_reference/4_objects/cms/0_pages/0_nth/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_pages/0_nth/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 // echo the title of the 4th subpage

--- a/content/docs/2_reference/4_objects/cms/0_pages/0_offset/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_pages/0_offset/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <ul>

--- a/content/docs/2_reference/4_objects/cms/0_pages/0_paginate/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_pages/0_paginate/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Examples
+Example:s
 
 ### `$arguments` is an option array
 

--- a/content/docs/2_reference/4_objects/cms/0_pages/0_pluck/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_pages/0_pluck/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <ul>

--- a/content/docs/2_reference/4_objects/cms/0_pages/0_prepend/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_pages/0_prepend/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 $collection = page('projects')->children()->limit(1);

--- a/content/docs/2_reference/4_objects/cms/0_pages/0_shuffle/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_pages/0_shuffle/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text:
-
-## Example
+Example:
 
 ```php
 <h2>Random subpages</h2>

--- a/content/docs/2_reference/4_objects/cms/0_pages/0_slice/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_pages/0_slice/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <ul>

--- a/content/docs/2_reference/4_objects/cms/0_pages/0_sort-by/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_pages/0_sort-by/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text:
-
-## Example
+Example:
 
 ```php
 <ul>

--- a/content/docs/2_reference/4_objects/cms/0_pages/0_unlisted/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_pages/0_unlisted/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <h2>Unlisted subpages</h2>

--- a/content/docs/2_reference/4_objects/cms/0_pages/0_when/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_pages/0_when/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text:
-
-## Examples
+Example:s
 
 Apply the filter method only if the first parameter evaluates to `true`:
 

--- a/content/docs/2_reference/4_objects/cms/0_pagination/0_first-page-url/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_pagination/0_first-page-url/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 $subpages   = $page->children()->paginate(10);

--- a/content/docs/2_reference/4_objects/cms/0_pagination/0_first-page/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_pagination/0_first-page/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 $subpages   = $page->children()->paginate(10);

--- a/content/docs/2_reference/4_objects/cms/0_pagination/0_has-next-page/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_pagination/0_has-next-page/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?php

--- a/content/docs/2_reference/4_objects/cms/0_pagination/0_has-pages/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_pagination/0_has-pages/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?php

--- a/content/docs/2_reference/4_objects/cms/0_pagination/0_has-prev-page/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_pagination/0_has-prev-page/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?php

--- a/content/docs/2_reference/4_objects/cms/0_pagination/0_is-first-page/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_pagination/0_is-first-page/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 $subpages   = $page->children()->paginate(10);

--- a/content/docs/2_reference/4_objects/cms/0_pagination/0_is-last-page/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_pagination/0_is-last-page/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 $subpages   = $page->children()->paginate(10);

--- a/content/docs/2_reference/4_objects/cms/0_pagination/0_last-page-url/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_pagination/0_last-page-url/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?php

--- a/content/docs/2_reference/4_objects/cms/0_pagination/0_last-page/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_pagination/0_last-page/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 $subpages   = $page->children()->paginate(10);

--- a/content/docs/2_reference/4_objects/cms/0_pagination/0_limit/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_pagination/0_limit/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 $subpages   = $page->children()->paginate(10);

--- a/content/docs/2_reference/4_objects/cms/0_pagination/0_next-page-url/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_pagination/0_next-page-url/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?php

--- a/content/docs/2_reference/4_objects/cms/0_pagination/0_next-page/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_pagination/0_next-page/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?php

--- a/content/docs/2_reference/4_objects/cms/0_pagination/0_page/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_pagination/0_page/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?php

--- a/content/docs/2_reference/4_objects/cms/0_pagination/0_prev-page-url/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_pagination/0_prev-page-url/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?php

--- a/content/docs/2_reference/4_objects/cms/0_pagination/0_prev-page/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_pagination/0_prev-page/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?php

--- a/content/docs/2_reference/4_objects/cms/0_responder/0_cache/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_responder/0_cache/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text:
-
-## Example
+Example:
 
 ```php
 <?php

--- a/content/docs/2_reference/4_objects/cms/0_responder/0_expires/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_responder/0_expires/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text:
-
-## Example
+Example:
 
 ```php
 <?php

--- a/content/docs/2_reference/4_objects/cms/0_site/0_audio/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_site/0_audio/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <h2>Songs</h2>

--- a/content/docs/2_reference/4_objects/cms/0_site/0_breadcrumb/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_site/0_breadcrumb/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <nav class="breadcrumb" aria-label="breadcrumb">

--- a/content/docs/2_reference/4_objects/cms/0_site/0_change-title/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_site/0_change-title/reference-classmethod.txt
@@ -1,9 +1,7 @@
 Auth: site.changeTitle
 
 ----
-Text:
-
-## Example
+Example:
 
 ```php
 <?php

--- a/content/docs/2_reference/4_objects/cms/0_site/0_children-and-drafts/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_site/0_children-and-drafts/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?php foreach ($site->childrenAndDrafts() as $item) {

--- a/content/docs/2_reference/4_objects/cms/0_site/0_code/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_site/0_code/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?php foreach($site->code()->filterBy('extension', 'css') as $css): ?>

--- a/content/docs/2_reference/4_objects/cms/0_site/0_create-child/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_site/0_create-child/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 Programmatically create a new page as child of the `$site` object.
 

--- a/content/docs/2_reference/4_objects/cms/0_site/0_create-file/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_site/0_create-file/reference-classmethod.txt
@@ -5,9 +5,7 @@ Auth: files.create
 Properties: $props|Kirby\Cms\File
 
 ----
-Text:
-
-## Example
+Example:
 
 ```php
 <?php

--- a/content/docs/2_reference/4_objects/cms/0_site/0_documents/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_site/0_documents/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <h2>Available PDFs</h2>

--- a/content/docs/2_reference/4_objects/cms/0_site/0_draft/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_site/0_draft/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?php

--- a/content/docs/2_reference/4_objects/cms/0_site/0_error-page/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_site/0_error-page/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?= $site->errorPage()->text() ?>

--- a/content/docs/2_reference/4_objects/cms/0_site/0_file/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_site/0_file/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ### Fetching the first file
 

--- a/content/docs/2_reference/4_objects/cms/0_site/0_files/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_site/0_files/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <h2>Files</h2>

--- a/content/docs/2_reference/4_objects/cms/0_site/0_find-page-or-draft/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_site/0_find-page-or-draft/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?php

--- a/content/docs/2_reference/4_objects/cms/0_site/0_find/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_site/0_find/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ### Fetch a single subpage
 

--- a/content/docs/2_reference/4_objects/cms/0_site/0_grand-children/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_site/0_grand-children/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example structure
+Example: structure
 
 - content
     - home

--- a/content/docs/2_reference/4_objects/cms/0_site/0_has-audio/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_site/0_has-audio/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?php if($site->hasAudio()): ?>

--- a/content/docs/2_reference/4_objects/cms/0_site/0_has-children/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_site/0_has-children/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?php if($site->hasChildren()): ?>

--- a/content/docs/2_reference/4_objects/cms/0_site/0_has-code/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_site/0_has-code/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?php if($site->hasCode()): ?>

--- a/content/docs/2_reference/4_objects/cms/0_site/0_has-documents/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_site/0_has-documents/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?php if($site->hasDocuments()): ?>

--- a/content/docs/2_reference/4_objects/cms/0_site/0_has-files/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_site/0_has-files/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?php if($site->hasFiles()): ?>

--- a/content/docs/2_reference/4_objects/cms/0_site/0_has-images/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_site/0_has-images/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?php if($site->hasImages()): ?>

--- a/content/docs/2_reference/4_objects/cms/0_site/0_has-listed-children/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_site/0_has-listed-children/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?php if($site->hasListedChildren()): ?>

--- a/content/docs/2_reference/4_objects/cms/0_site/0_has-unlisted-children/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_site/0_has-unlisted-children/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?php if($site->hasUnlistedChildren()): ?>

--- a/content/docs/2_reference/4_objects/cms/0_site/0_has-videos/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_site/0_has-videos/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?php if($site->hasVideos()): ?>

--- a/content/docs/2_reference/4_objects/cms/0_site/0_home-page/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_site/0_home-page/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?= $site->homePage()->text() ?>

--- a/content/docs/2_reference/4_objects/cms/0_site/0_id/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_site/0_id/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?= $site->id() ?>

--- a/content/docs/2_reference/4_objects/cms/0_site/0_image/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_site/0_image/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ### Fetching the first image
 

--- a/content/docs/2_reference/4_objects/cms/0_site/0_images/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_site/0_images/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <section class="gallery">

--- a/content/docs/2_reference/4_objects/cms/0_site/0_modified/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_site/0_modified/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 Last update: <?= $site->modified('d/m/Y H:i') ?>

--- a/content/docs/2_reference/4_objects/cms/0_site/0_page/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_site/0_page/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ### Fetching the current page
 

--- a/content/docs/2_reference/4_objects/cms/0_site/0_pages/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_site/0_pages/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <nav class="main-menu" role="navigation">

--- a/content/docs/2_reference/4_objects/cms/0_site/0_query/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_site/0_query/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?php

--- a/content/docs/2_reference/4_objects/cms/0_site/0_save/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_site/0_save/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text:
-
-## Example
+Example:
 
 ```php
 <?php

--- a/content/docs/2_reference/4_objects/cms/0_site/0_update/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_site/0_update/reference-classmethod.txt
@@ -2,9 +2,7 @@ Auth: site.update
 
 ----
 
-Text:
-
-## Example
+Example:
 
 ```php
 try {

--- a/content/docs/2_reference/4_objects/cms/0_site/0_url-for-language/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_site/0_url-for-language/reference-classmethod.txt
@@ -1,9 +1,8 @@
-Text: 
+Text:
 
 If a $lang parameter is specified (multi-language site only), the specific language URL is returned.
 
 ## Example
-
 
 ### Fetching the base URL for a language
 

--- a/content/docs/2_reference/4_objects/cms/0_site/0_videos/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_site/0_videos/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <h2>Videos</h2>

--- a/content/docs/2_reference/4_objects/cms/0_structure/0_group/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_structure/0_group/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text:
-
-## Example
+Example:
 
 ```php
 <!-- group the collection by the field `category` -->

--- a/content/docs/2_reference/4_objects/cms/0_user/0_avatar/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_user/0_avatar/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?php if($avatar = $kirby->user('bastian@example.com')->avatar()): ?>

--- a/content/docs/2_reference/4_objects/cms/0_user/0_create/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_user/0_create/reference-classmethod.txt
@@ -6,9 +6,7 @@ Properties: $props
 
 ----
 
-Text:
-
-## Example
+Example:
 
 ```php
 $newUser = User::create([

--- a/content/docs/2_reference/4_objects/cms/0_user/0_delete/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_user/0_delete/reference-classmethod.txt
@@ -2,9 +2,7 @@ Auth: users.delete
 
 ----
 
-Text:
-
-## Example
+Example:
 
 ```php
 try {

--- a/content/docs/2_reference/4_objects/cms/0_user/0_email/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_user/0_email/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?= $kirby->user('bastian@example.com')->email() ?>

--- a/content/docs/2_reference/4_objects/cms/0_user/0_is/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_user/0_is/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?php if($kirby->user()->is($kirby->user('bastian@example.com'))): ?>

--- a/content/docs/2_reference/4_objects/cms/0_user/0_login-passwordless/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_user/0_login-passwordless/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 // simple login form submission example
@@ -12,11 +10,11 @@ if($username = get('username') && $password = get('password')) {
     // verify access with a different method like
     // OAuth, IndieAuth, email or SMS token etc.
     myCustomAuthProvider();
-  
+
     // now that that succeeded, log the user in without checking the provided password
     // NOTE: Only use this if you have verified access in other ways like in this example!
     $user->loginPasswordless();
-    
+
     // redirect to the homepage
     // or any other page
     go();

--- a/content/docs/2_reference/4_objects/cms/0_user/0_login/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_user/0_login/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 // simple login form submission example

--- a/content/docs/2_reference/4_objects/cms/0_user/0_logout/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_user/0_logout/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?php

--- a/content/docs/2_reference/4_objects/cms/0_user/0_update/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_user/0_update/reference-classmethod.txt
@@ -2,9 +2,7 @@ Auth: users.update
 
 ----
 
-Text:
-
-## Example
+Example:
 
 ```php
 try {

--- a/content/docs/2_reference/4_objects/cms/0_user/0_username/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_user/0_username/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text: 
-
-## Example
+Example:
 
 ```php
 <?= $kirby->user('bastian@example.com')->username() ?>

--- a/content/docs/2_reference/4_objects/cms/0_users/0_create/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_users/0_create/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text:
-
-## Example
+Example:
 
 ```php
 try {

--- a/content/docs/2_reference/4_objects/cms/0_users/0_intersection/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_users/0_intersection/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text:
-
-## Example
+Example:
 
 ```php
 $users1 = $kirby->users()->role('admin');

--- a/content/docs/2_reference/4_objects/cms/0_users/0_intersects/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_users/0_intersects/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text:
-
-## Example
+Example:
 
 ```php
 $users1 = $kirby->users()->role('admin');

--- a/content/docs/2_reference/4_objects/database/0_database/0_create-table/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/database/0_database/0_create-table/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text:
-
-## Example
+Example:
 
 ```php
 $database->createTable('product', [

--- a/content/docs/2_reference/4_objects/filesystem/0_file/0_sha1/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/filesystem/0_file/0_sha1/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text:
-
-## Example
+Example:
 
 ```php
 $hashA = $fileA->sha1();

--- a/content/docs/2_reference/4_objects/http/0_remote/0_code/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/http/0_remote/0_code/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text:
-
-## Example
+Example:
 
 ```php
 <?php

--- a/content/docs/2_reference/4_objects/http/0_remote/0_content/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/http/0_remote/0_content/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text:
-
-## Example
+Example:
 
 Response content can be in different formats depending on what what is returned from the endpoint.
 

--- a/content/docs/2_reference/4_objects/http/0_remote/0_headers/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/http/0_remote/0_headers/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text:
-
-## Example
+Example:
 
 ```php
 <?php

--- a/content/docs/2_reference/4_objects/http/0_remote/0_info/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/http/0_remote/0_info/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text:
-
-## Example
+Example:
 
 ```php
 <?php

--- a/content/docs/2_reference/4_objects/http/0_remote/0_json/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/http/0_remote/0_json/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text:
-
-## Example
+Example:
 
 If the respons content is a JSON response, you can use the `$remote->json()` method to covert the content to an array or object.
 

--- a/content/docs/2_reference/4_objects/toolkit/0_a/0_implode/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/toolkit/0_a/0_implode/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text:
-
-## Example
+Example:
 
 ```php
 $array = ['a', 'b', ['cc', 'dd']];

--- a/content/docs/2_reference/4_objects/toolkit/0_a/0_map/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/toolkit/0_a/0_map/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text:
-
-## Example
+Example:
 
 ```php
 // why this weird, inconsistent argument order?

--- a/content/docs/2_reference/4_objects/toolkit/0_html/0_attr/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/toolkit/0_html/0_attr/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text:
-
-## Examples
+Example:
 
 ```php
 // single attributes

--- a/content/docs/2_reference/4_objects/toolkit/0_xml/0_attr/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/toolkit/0_xml/0_attr/reference-classmethod.txt
@@ -1,6 +1,4 @@
-Text:
-
-## Examples
+Example:
 
 ```php
 // single attributes

--- a/site/models/reference-classmethod.php
+++ b/site/models/reference-classmethod.php
@@ -33,6 +33,19 @@ class ReferenceClassMethodPage extends ReflectionPage
 		return $this->parent()->name($short);
 	}
 
+	public function example(): Field
+	{
+		if ($this->content()->has('example')) {
+			return $this->content()->get('example');
+		}
+
+		if ($docBlock = $this->docBlock()) {
+			$example = trim($docBlock->getDescription());
+		}
+
+		return new Field($this, 'example', $example ?? null);
+	}
+
 	public function exists(): bool
 	{
 		return method_exists($this->class(), $this->name());

--- a/site/templates/reference-classmethod.php
+++ b/site/templates/reference-classmethod.php
@@ -5,4 +5,9 @@
 	<?php snippet('templates/reference/entry/class') ?>
 
 	<?= $page->text()->kt() ?>
+
+	<?php if ($page->example()->isNotEmpty()): ?>
+		<h2>Example</h2>
+		<?= $page->example()->kt() ?>
+	<?php endif ?>
 </div>


### PR DESCRIPTION
Uses the core code docblocks to display the whole description of the method docblock as `Example`.

@bastianallgeier @lukasbestle 
What do you think about this idea? I think it would allow us to add more examples in-code that we would never maintain manually in the reference. But are there docblocks featuring other description parts than examples?