### PR TITLE
Use final URLs after redirects in menus

### DIFF
--- a/site/controllers/terms.php
+++ b/site/controllers/terms.php
@@ -6,9 +6,7 @@ use Kirby\Cms\Page;
 
 return function (App $kirby, Page $page) {
 	// redirect from the parent to the latest version
-	$latest = $page->children()->last();
-
-	if ($latest?->intendedTemplate()->name() === 'terms') {
+	if ($latest = $page->latestVersion()) {
 		return go($latest, 302);
 	}
 

--- a/site/layouts/features.php
+++ b/site/layouts/features.php
@@ -37,12 +37,12 @@
 							'buttons' => [
 								[
 									'text' => 'Try now',
-									'link' => '/try',
+									'link' => page('try')->menuUrl(),
 									'icon' => 'download'
 								],
 								[
 									'text'  => 'Docs',
-									'link'  => '/docs/guide',
+									'link'  => page('docs/guide')->menuUrl(),
 									'icon'  => 'book',
 									'style' => 'outlined'
 								]

--- a/site/models/buzz-entry.php
+++ b/site/models/buzz-entry.php
@@ -1,10 +1,11 @@
 <?php
 
-use Kirby\Cms\Page;
 use Kirby\Content\Field;
 use Kirby\Toolkit\Str;
 
-class BuzzEntryPage extends Page
+require_once __DIR__ . '/default.php';
+
+class BuzzEntryPage extends DefaultPage
 {
 	public function blurb(): Field
 	{

--- a/site/models/buzz-entry.php
+++ b/site/models/buzz-entry.php
@@ -19,11 +19,6 @@ class BuzzEntryPage extends DefaultPage
 			Str::startsWith($url, $this->site()->url()) === false;
 	}
 
-	public function menuUrl(): string
-	{
-		return $this->url();
-	}
-
 	public function url($options = null): string
 	{
 		if ($this->link()->isNotEmpty() === true) {

--- a/site/models/buzz-entry.php
+++ b/site/models/buzz-entry.php
@@ -18,6 +18,11 @@ class BuzzEntryPage extends Page
 			Str::startsWith($url, $this->site()->url()) === false;
 	}
 
+	public function menuUrl(): string
+	{
+		return $this->url();
+	}
+
 	public function url($options = null): string
 	{
 		if ($this->link()->isNotEmpty() === true) {

--- a/site/models/buzz-entry.php
+++ b/site/models/buzz-entry.php
@@ -3,8 +3,6 @@
 use Kirby\Content\Field;
 use Kirby\Toolkit\Str;
 
-require_once __DIR__ . '/default.php';
-
 class BuzzEntryPage extends DefaultPage
 {
 	public function blurb(): Field

--- a/site/models/cookbook-recipe.php
+++ b/site/models/cookbook-recipe.php
@@ -1,9 +1,10 @@
 <?php
 
-use Kirby\Cms\Page;
 use Kirby\Cms\Pages;
 
-class CookbookRecipePage extends Page
+require_once __DIR__ . '/default.php';
+
+class CookbookRecipePage extends DefaultPage
 {
 	public function authors(): Pages
 	{

--- a/site/models/cookbook-recipe.php
+++ b/site/models/cookbook-recipe.php
@@ -2,8 +2,6 @@
 
 use Kirby\Cms\Pages;
 
-require_once __DIR__ . '/default.php';
-
 class CookbookRecipePage extends DefaultPage
 {
 	public function authors(): Pages

--- a/site/models/default.php
+++ b/site/models/default.php
@@ -8,7 +8,7 @@ class DefaultPage extends Page
 	 * Checks whether the page is the current page in a menu context,
 	 * considering redirects to other pages
 	 */
-	public function isActiveInMenu(bool $hasSubmenu = false): bool
+	public function isActive(bool $hasSubmenu = false): bool
 	{
 		$currentPage = $this->site()->page();
 

--- a/site/models/default.php
+++ b/site/models/default.php
@@ -1,6 +1,7 @@
 <?php
 
 use Kirby\Cms\Page;
+use Kirby\Toolkit\Str;
 
 class DefaultPage extends Page
 {
@@ -20,6 +21,21 @@ class DefaultPage extends Page
 
 		// otherwise use the menu URL for the comparison
 		return $this->menuUrl() === $currentPage?->menuUrl();
+	}
+
+	/**
+	 * Checks whether the page is the current page or one of its ancestors
+	 * in a menu context, considering redirects to other pages
+	 */
+	public function isOpen(): bool
+	{
+		$currentPage = $this->site()->page();
+
+		if (Str::startsWith($currentPage?->menuUrl(), $this->menuUrl() . '/') === true) {
+			return true;
+		}
+
+		return parent::isOpen();
 	}
 
 	/**

--- a/site/models/default.php
+++ b/site/models/default.php
@@ -1,11 +1,15 @@
 <?php
 
-return [
+use Kirby\Cms\Page;
+
+class DefaultPage extends Page
+{
 	/**
 	 * Checks whether the page is the current page in a menu context,
 	 * considering redirects to other pages
 	 */
-	'isActiveInMenu' => function (bool $hasSubmenu = false) {
+	public function isActiveInMenu(bool $hasSubmenu = false): bool
+	{
 		$currentPage = $this->site()->page();
 
 		// catch cases where the menu URL points to a child
@@ -15,12 +19,15 @@ return [
 		}
 
 		// otherwise use the menu URL for the comparison
-		return $this->menuUrl() === $this->site()->page()?->url();
-	},
+		return $this->menuUrl() === $currentPage?->menuUrl();
+	}
 
 	/**
 	 * Final URL after redirects to be used in menus;
 	 * fallback if the page model doesn't override it
 	 */
-	'menuUrl' => fn () => $this->url()
-];
+	public function menuUrl(): string
+	{
+		return $this->url();
+	}
+}

--- a/site/models/glossary-entry.php
+++ b/site/models/glossary-entry.php
@@ -6,6 +6,6 @@ class GlossaryEntryPage extends DefaultPage
 {
 	public function menuUrl(): string
 	{
-		return $this->link()->or($this->url())->value();
+		return $this->link()->toUrl() ?? $this->url();
 	}
 }

--- a/site/models/glossary-entry.php
+++ b/site/models/glossary-entry.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once __DIR__ . '/default.php';
-
 class GlossaryEntryPage extends DefaultPage
 {
 	public function menuUrl(): string

--- a/site/models/glossary-entry.php
+++ b/site/models/glossary-entry.php
@@ -2,15 +2,10 @@
 
 use Kirby\Cms\Page;
 
-class ReleaseGuidePage extends Page
+class GlossaryEntryPage extends Page
 {
 	public function menuUrl(): string
 	{
 		return $this->link()->or($this->url())->value();
-	}
-
-	public function release()
-	{
-		return $this->parents()->not('releases')->last();
 	}
 }

--- a/site/models/glossary-entry.php
+++ b/site/models/glossary-entry.php
@@ -1,8 +1,8 @@
 <?php
 
-use Kirby\Cms\Page;
+require_once __DIR__ . '/default.php';
 
-class GlossaryEntryPage extends Page
+class GlossaryEntryPage extends DefaultPage
 {
 	public function menuUrl(): string
 	{

--- a/site/models/guide.php
+++ b/site/models/guide.php
@@ -9,6 +9,15 @@ class GuidePage extends Page
 		return $this->text()->isEmpty() && $this->hasChildren();
 	}
 
+	public function menuUrl(): string
+	{
+		if ($this->isChapter()) {
+			return $this->children()->first()->url();
+		}
+
+		return parent::url();
+	}
+
 	public function metadata(): array
 	{
 		return [

--- a/site/models/guide.php
+++ b/site/models/guide.php
@@ -1,8 +1,8 @@
 <?php
 
-use Kirby\Cms\Page;
+require_once __DIR__ . '/default.php';
 
-class GuidePage extends Page
+class GuidePage extends DefaultPage
 {
 	public function isChapter(): bool
 	{

--- a/site/models/guide.php
+++ b/site/models/guide.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once __DIR__ . '/default.php';
-
 class GuidePage extends DefaultPage
 {
 	public function isChapter(): bool

--- a/site/models/guides.php
+++ b/site/models/guides.php
@@ -1,8 +1,8 @@
 <?php
 
-use Kirby\Cms\Page;
+require_once __DIR__ . '/default.php';
 
-class GuidesPage extends Page
+class GuidesPage extends DefaultPage
 {
 	public function menuUrl(): string
 	{

--- a/site/models/guides.php
+++ b/site/models/guides.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once __DIR__ . '/default.php';
-
 class GuidesPage extends DefaultPage
 {
 	public function menuUrl(): string

--- a/site/models/guides.php
+++ b/site/models/guides.php
@@ -1,0 +1,11 @@
+<?php
+
+use Kirby\Cms\Page;
+
+class GuidesPage extends Page
+{
+	public function menuUrl(): string
+	{
+		return collection('guides')->first()->menuUrl();
+	}
+}

--- a/site/models/kosmos-issue.php
+++ b/site/models/kosmos-issue.php
@@ -1,8 +1,8 @@
 <?php
 
-use Kirby\Cms\Page;
+require_once __DIR__ . '/default.php';
 
-class KosmosIssuePage extends Page
+class KosmosIssuePage extends DefaultPage
 {
 	public function metadata(): array
 	{

--- a/site/models/kosmos-issue.php
+++ b/site/models/kosmos-issue.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once __DIR__ . '/default.php';
-
 class KosmosIssuePage extends DefaultPage
 {
 	public function metadata(): array

--- a/site/models/legacy.php
+++ b/site/models/legacy.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once __DIR__ . '/default.php';
-
 class LegacyPage extends DefaultPage
 {
 	public function menuUrl(): string

--- a/site/models/legacy.php
+++ b/site/models/legacy.php
@@ -1,0 +1,11 @@
+<?php
+
+use Kirby\Cms\Page;
+
+class LegacyPage extends Page
+{
+	public function menuUrl(): string
+	{
+		return $this->src()->value();
+	}
+}

--- a/site/models/legacy.php
+++ b/site/models/legacy.php
@@ -1,8 +1,8 @@
 <?php
 
-use Kirby\Cms\Page;
+require_once __DIR__ . '/default.php';
 
-class LegacyPage extends Page
+class LegacyPage extends DefaultPage
 {
 	public function menuUrl(): string
 	{

--- a/site/models/link.php
+++ b/site/models/link.php
@@ -6,6 +6,6 @@ class LinkPage extends DefaultPage
 {
 	public function menuUrl(): string
 	{
-		return $this->link()->value();
+		return url($this->link()->value());
 	}
 }

--- a/site/models/link.php
+++ b/site/models/link.php
@@ -2,15 +2,10 @@
 
 use Kirby\Cms\Page;
 
-class ThemePage extends Page
+class LinkPage extends Page
 {
 	public function menuUrl(): string
 	{
 		return $this->link()->value();
-	}
-
-	public function prio()
-	{
-		return parent::prio()->or(9999);
 	}
 }

--- a/site/models/link.php
+++ b/site/models/link.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once __DIR__ . '/default.php';
-
 class LinkPage extends DefaultPage
 {
 	public function menuUrl(): string

--- a/site/models/link.php
+++ b/site/models/link.php
@@ -6,6 +6,6 @@ class LinkPage extends DefaultPage
 {
 	public function menuUrl(): string
 	{
-		return url($this->link()->value());
+		return $this->link()->toUrl();
 	}
 }

--- a/site/models/link.php
+++ b/site/models/link.php
@@ -1,8 +1,8 @@
 <?php
 
-use Kirby\Cms\Page;
+require_once __DIR__ . '/default.php';
 
-class LinkPage extends Page
+class LinkPage extends DefaultPage
 {
 	public function menuUrl(): string
 	{

--- a/site/models/meet-events.php
+++ b/site/models/meet-events.php
@@ -1,12 +1,13 @@
 <?php
 
-use Kirby\Cms\Page;
 use Kirby\Cms\Pages;
 use Kirby\Http\Remote;
 use Kirby\Toolkit\Date;
 use Kirby\Toolkit\Str;
 
-class MeetEventsPage extends Page
+require_once __DIR__ . '/default.php';
+
+class MeetEventsPage extends DefaultPage
 {
 	public function children(): Pages
 	{

--- a/site/models/meet-events.php
+++ b/site/models/meet-events.php
@@ -5,8 +5,6 @@ use Kirby\Http\Remote;
 use Kirby\Toolkit\Date;
 use Kirby\Toolkit\Str;
 
-require_once __DIR__ . '/default.php';
-
 class MeetEventsPage extends DefaultPage
 {
 	public function children(): Pages

--- a/site/models/partner.php
+++ b/site/models/partner.php
@@ -1,12 +1,13 @@
 <?php
 
 use Kirby\Cms\File;
-use Kirby\Cms\Page;
 use Kirby\Cms\Pages;
 use Kirby\Content\Field;
 use Kirby\Toolkit\Str;
 
-class PartnerPage extends Page
+require_once __DIR__ . '/default.php';
+
+class PartnerPage extends DefaultPage
 {
 	public function avatar(): File|null
 	{

--- a/site/models/partner.php
+++ b/site/models/partner.php
@@ -5,8 +5,6 @@ use Kirby\Cms\Pages;
 use Kirby\Content\Field;
 use Kirby\Toolkit\Str;
 
-require_once __DIR__ . '/default.php';
-
 class PartnerPage extends DefaultPage
 {
 	public function avatar(): File|null

--- a/site/models/plugin-developer.php
+++ b/site/models/plugin-developer.php
@@ -1,13 +1,14 @@
 <?php
 
 use Kirby\Cms\File;
-use Kirby\Cms\Page;
 use Kirby\Content\Field;
+
+require_once __DIR__ . '/default.php';
 
 /**
  * TODO: Remove when plugin content is no longer in the repo
  */
-class PluginDeveloperPage extends Page
+class PluginDeveloperPage extends DefaultPage
 {
 	public function avatar(): File|null
 	{

--- a/site/models/plugin-developer.php
+++ b/site/models/plugin-developer.php
@@ -3,8 +3,6 @@
 use Kirby\Cms\File;
 use Kirby\Content\Field;
 
-require_once __DIR__ . '/default.php';
-
 /**
  * TODO: Remove when plugin content is no longer in the repo
  */

--- a/site/models/plugin.php
+++ b/site/models/plugin.php
@@ -3,7 +3,6 @@
 use Kirby\Cache\Cache;
 use Kirby\Cms\File;
 use Kirby\Cms\Nest;
-use Kirby\Cms\Page;
 use Kirby\Content\Field;
 use Kirby\Data\Data;
 use Kirby\Github\Github;
@@ -12,10 +11,12 @@ use Kirby\Http\Url;
 use Kirby\Toolkit\Obj;
 use Kirby\Toolkit\Str;
 
+require_once __DIR__ . '/default.php';
+
 /**
  * TODO: Remove when plugin content is no longer in the repo
  */
-class PluginPage extends Page
+class PluginPage extends DefaultPage
 {
 	protected $info = null;
 	protected $latestTag = null;

--- a/site/models/plugin.php
+++ b/site/models/plugin.php
@@ -11,8 +11,6 @@ use Kirby\Http\Url;
 use Kirby\Toolkit\Obj;
 use Kirby\Toolkit\Str;
 
-require_once __DIR__ . '/default.php';
-
 /**
  * TODO: Remove when plugin content is no longer in the repo
  */

--- a/site/models/quicktip.php
+++ b/site/models/quicktip.php
@@ -1,9 +1,10 @@
 <?php
 
-use Kirby\Cms\Page;
 use Kirby\Cms\Pages;
 
-class QuicktipPage extends Page
+require_once __DIR__ . '/default.php';
+
+class QuicktipPage extends DefaultPage
 {
 	public function authors(): Pages
 	{

--- a/site/models/quicktip.php
+++ b/site/models/quicktip.php
@@ -2,8 +2,6 @@
 
 use Kirby\Cms\Pages;
 
-require_once __DIR__ . '/default.php';
-
 class QuicktipPage extends DefaultPage
 {
 	public function authors(): Pages

--- a/site/models/reference-article.php
+++ b/site/models/reference-article.php
@@ -1,8 +1,8 @@
 <?php
 
-use Kirby\Cms\Page;
+require_once __DIR__ . '/default.php';
 
-class ReferenceArticlePage extends Page
+class ReferenceArticlePage extends DefaultPage
 {
 	public function metadata(): array
 	{

--- a/site/models/reference-article.php
+++ b/site/models/reference-article.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once __DIR__ . '/default.php';
-
 class ReferenceArticlePage extends DefaultPage
 {
 	public function metadata(): array

--- a/site/models/reference-classes.php
+++ b/site/models/reference-classes.php
@@ -62,7 +62,7 @@ class ReferenceClassesPage extends SectionPage
 			'num'      => 1,
 			'content'  => [
 				'title' => 'All classes',
-				'link'  => '/docs/reference/objects'
+				'link'  => url('docs/reference/objects')
 			]
 		];
 

--- a/site/models/reference-classes.php
+++ b/site/models/reference-classes.php
@@ -152,7 +152,7 @@ class ReferenceClassesPage extends SectionPage
 			]);
 	}
 
-	public function isActive(): bool
+	public function isActive(bool $hasSubmenu = false): bool
 	{
 		return false;
 	}

--- a/site/models/reference-classes.php
+++ b/site/models/reference-classes.php
@@ -152,11 +152,6 @@ class ReferenceClassesPage extends SectionPage
 			]);
 	}
 
-	public function isActive(bool $hasSubmenu = false): bool
-	{
-		return false;
-	}
-
 	public static function isFeatured(string $page): bool
 	{
 		$ids = [

--- a/site/models/reference-quicklink.php
+++ b/site/models/reference-quicklink.php
@@ -49,14 +49,6 @@ class ReferenceQuickLinkPage extends DefaultPage
 		return $children;
 	}
 
-	/**
-	 * Returns whether the referenced page is open
-	 */
-	public function isOpen(): bool
-	{
-		return $this->link()->toPage()?->isOpen() ?? false;
-	}
-
 	public function template(): Template
 	{
 		return $this->kirby()->template('link');

--- a/site/models/reference-quicklink.php
+++ b/site/models/reference-quicklink.php
@@ -49,6 +49,11 @@ class ReferenceQuickLinkPage extends DefaultPage
 		return $children;
 	}
 
+	public function menuUrl(): string
+	{
+		return url($this->link()->value());
+	}
+
 	public function template(): Template
 	{
 		return $this->kirby()->template('link');

--- a/site/models/reference-quicklink.php
+++ b/site/models/reference-quicklink.php
@@ -1,12 +1,13 @@
 <?php
 
-use Kirby\Cms\Page;
 use Kirby\Cms\Pages;
 use Kirby\Content\Field;
 use Kirby\Template\Template;
 use Kirby\Toolkit\Str;
 
-class ReferenceQuickLinkPage extends Page
+require_once __DIR__ . '/default.php';
+
+class ReferenceQuickLinkPage extends DefaultPage
 {
 	/**
 	 * Creates children collection from `menu` content field

--- a/site/models/reference-quicklink.php
+++ b/site/models/reference-quicklink.php
@@ -5,8 +5,6 @@ use Kirby\Content\Field;
 use Kirby\Template\Template;
 use Kirby\Toolkit\Str;
 
-require_once __DIR__ . '/default.php';
-
 class ReferenceQuickLinkPage extends DefaultPage
 {
 	/**

--- a/site/models/reference-quicklink.php
+++ b/site/models/reference-quicklink.php
@@ -51,7 +51,7 @@ class ReferenceQuickLinkPage extends DefaultPage
 
 	public function menuUrl(): string
 	{
-		return url($this->link()->value());
+		return $this->link()->toUrl();
 	}
 
 	public function template(): Template

--- a/site/models/release-guide.php
+++ b/site/models/release-guide.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once __DIR__ . '/default.php';
-
 class ReleaseGuidePage extends DefaultPage
 {
 	public function menuUrl(): string

--- a/site/models/release-guide.php
+++ b/site/models/release-guide.php
@@ -1,8 +1,8 @@
 <?php
 
-use Kirby\Cms\Page;
+require_once __DIR__ . '/default.php';
 
-class ReleaseGuidePage extends Page
+class ReleaseGuidePage extends DefaultPage
 {
 	public function menuUrl(): string
 	{

--- a/site/models/release-guide.php
+++ b/site/models/release-guide.php
@@ -6,7 +6,7 @@ class ReleaseGuidePage extends DefaultPage
 {
 	public function menuUrl(): string
 	{
-		return $this->link()->or($this->url())->value();
+		return $this->link()->toUrl() ?? $this->url();
 	}
 
 	public function release()

--- a/site/models/release.php
+++ b/site/models/release.php
@@ -2,8 +2,6 @@
 
 use Kirby\Template\Template;
 
-require_once __DIR__ . '/default.php';
-
 class ReleasePage extends DefaultPage
 {
 	public function template(): Template

--- a/site/models/release.php
+++ b/site/models/release.php
@@ -1,9 +1,10 @@
 <?php
 
-use Kirby\Cms\Page;
 use Kirby\Template\Template;
 
-class ReleasePage extends Page
+require_once __DIR__ . '/default.php';
+
+class ReleasePage extends DefaultPage
 {
 	public function template(): Template
 	{

--- a/site/models/security.php
+++ b/site/models/security.php
@@ -3,8 +3,6 @@
 use Kirby\Content\Field;
 use Kirby\Toolkit\Str;
 
-require_once __DIR__ . '/default.php';
-
 class SecurityPage extends DefaultPage
 {
 	public function incidents(): array

--- a/site/models/security.php
+++ b/site/models/security.php
@@ -1,10 +1,11 @@
 <?php
 
-use Kirby\Cms\Page;
 use Kirby\Content\Field;
 use Kirby\Toolkit\Str;
 
-class SecurityPage extends Page
+require_once __DIR__ . '/default.php';
+
+class SecurityPage extends DefaultPage
 {
 	public function incidents(): array
 	{

--- a/site/models/terms.php
+++ b/site/models/terms.php
@@ -1,0 +1,24 @@
+<?php
+
+use Kirby\Cms\Page;
+
+class TermsPage extends Page
+{
+	public function latestVersion(): Page|null
+	{
+		$latest = $this->children()->last();
+
+		// terms is the template both for the parent and each version,
+		// so only use the child if `$this` is the parent
+		if ($latest?->intendedTemplate()->name() === 'terms') {
+			return $latest;
+		}
+
+		return null;
+	}
+
+	public function menuUrl(): string
+	{
+		return $this->latestVersion()->url() ?? $this->url();
+	}
+}

--- a/site/models/terms.php
+++ b/site/models/terms.php
@@ -21,6 +21,6 @@ class TermsPage extends DefaultPage
 
 	public function menuUrl(): string
 	{
-		return $this->latestVersion()->url() ?? $this->url();
+		return $this->latestVersion()?->url() ?? $this->url();
 	}
 }

--- a/site/models/terms.php
+++ b/site/models/terms.php
@@ -2,8 +2,6 @@
 
 use Kirby\Cms\Page;
 
-require_once __DIR__ . '/default.php';
-
 class TermsPage extends DefaultPage
 {
 	public function latestVersion(): Page|null

--- a/site/models/terms.php
+++ b/site/models/terms.php
@@ -2,7 +2,9 @@
 
 use Kirby\Cms\Page;
 
-class TermsPage extends Page
+require_once __DIR__ . '/default.php';
+
+class TermsPage extends DefaultPage
 {
 	public function latestVersion(): Page|null
 	{

--- a/site/models/theme-developer.php
+++ b/site/models/theme-developer.php
@@ -1,0 +1,11 @@
+<?php
+
+use Kirby\Cms\Page;
+
+class ThemeDeveloperPage extends Page
+{
+	public function menuUrl(): string
+	{
+		return $this->parent()->url();
+	}
+}

--- a/site/models/theme-developer.php
+++ b/site/models/theme-developer.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once __DIR__ . '/default.php';
-
 class ThemeDeveloperPage extends DefaultPage
 {
 	public function menuUrl(): string

--- a/site/models/theme-developer.php
+++ b/site/models/theme-developer.php
@@ -1,8 +1,8 @@
 <?php
 
-use Kirby\Cms\Page;
+require_once __DIR__ . '/default.php';
 
-class ThemeDeveloperPage extends Page
+class ThemeDeveloperPage extends DefaultPage
 {
 	public function menuUrl(): string
 	{

--- a/site/models/theme.php
+++ b/site/models/theme.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once __DIR__ . '/default.php';
-
 class ThemePage extends DefaultPage
 {
 	public function menuUrl(): string

--- a/site/models/theme.php
+++ b/site/models/theme.php
@@ -1,8 +1,8 @@
 <?php
 
-use Kirby\Cms\Page;
+require_once __DIR__ . '/default.php';
 
-class ThemePage extends Page
+class ThemePage extends DefaultPage
 {
 	public function menuUrl(): string
 	{

--- a/site/plugins/site/extensions/pageMethods.php
+++ b/site/plugins/site/extensions/pageMethods.php
@@ -1,0 +1,26 @@
+<?php
+
+return [
+	/**
+	 * Checks whether the page is the current page in a menu context,
+	 * considering redirects to other pages
+	 */
+	'isActiveInMenu' => function (bool $hasSubmenu = false) {
+		$currentPage = $this->site()->page();
+
+		// catch cases where the menu URL points to a child
+		// to avoid marking both the ancestor and child as active
+		if ($hasSubmenu === true && $this->isAncestorOf($currentPage) === true) {
+			return false;
+		}
+
+		// otherwise use the menu URL for the comparison
+		return $this->menuUrl() === $this->site()->page()?->url();
+	},
+
+	/**
+	 * Final URL after redirects to be used in menus;
+	 * fallback if the page model doesn't override it
+	 */
+	'menuUrl' => fn () => $this->url()
+];

--- a/site/plugins/site/index.php
+++ b/site/plugins/site/index.php
@@ -10,6 +10,5 @@ class_alias('Kirby\\Reference\\Types', 'Types');
 Kirby::plugin('getkirby/site', [
 	'components'   => include __DIR__ . '/extensions/components.php',
 	'fieldMethods' => include __DIR__ . '/extensions/fieldMethods.php',
-	'pageMethods'  => include __DIR__ . '/extensions/pageMethods.php',
 	'tags'         => include __DIR__ . '/extensions/tags.php'
 ]);

--- a/site/plugins/site/index.php
+++ b/site/plugins/site/index.php
@@ -5,6 +5,10 @@ require __DIR__ . '/vendor/autoload.php';
 require __DIR__ . '/helpers/html.php';
 require __DIR__ . '/helpers/reference.php';
 
+// make default page model available for extension
+// TODO: Remove when https://github.com/getkirby/kirby/issues/5968 is implemented
+require __DIR__ . '/../../models/default.php';
+
 class_alias('Kirby\\Reference\\Types', 'Types');
 
 Kirby::plugin('getkirby/site', [

--- a/site/plugins/site/index.php
+++ b/site/plugins/site/index.php
@@ -10,5 +10,6 @@ class_alias('Kirby\\Reference\\Types', 'Types');
 Kirby::plugin('getkirby/site', [
 	'components'   => include __DIR__ . '/extensions/components.php',
 	'fieldMethods' => include __DIR__ . '/extensions/fieldMethods.php',
+	'pageMethods'  => include __DIR__ . '/extensions/pageMethods.php',
 	'tags'         => include __DIR__ . '/extensions/tags.php'
 ]);

--- a/site/plugins/site/src/Reference/ReflectionPage.php
+++ b/site/plugins/site/src/Reference/ReflectionPage.php
@@ -2,8 +2,8 @@
 
 namespace Kirby\Reference;
 
+use DefaultPage;
 use Kirby\Cms\App;
-use Kirby\Cms\Page;
 use Kirby\Content\Field;
 use Kirby\Template\Template;
 use Kirby\Toolkit\A;
@@ -13,7 +13,7 @@ use ReflectionUnionType;
 use Reflector;
 use Throwable;
 
-abstract class ReflectionPage extends Page
+abstract class ReflectionPage extends DefaultPage
 {
 	protected DocBlock|null $docBlock;
 	protected array $parameters;

--- a/site/snippets/layouts/footer.php
+++ b/site/snippets/layouts/footer.php
@@ -34,57 +34,77 @@
 					<li>
 						<p class="font-bold mb-1">The CMS</p>
 						<ul class="footer-menu-2">
-							<li><a href="<?= page('features/developers')->menuUrl() ?>">For developers</a></li>
-							<li><a href="<?= page('features/designers')->menuUrl() ?>">For designers</a></li>
-							<li><a href="<?= page('features/creators')->menuUrl() ?>">For content creators</a></li>
-							<li><a href="<?= page('features/clients')->menuUrl() ?>">For clients & agencies</a></li>
-							<li><a href="<?= page('love')->menuUrl() ?>">Showcase</a></li>
-							<li><a href="<?= page('releases')->menuUrl() ?>">Releases</a></li>
-							<li><a href="https://feedback.getkirby.com">Feedback</a></li>
+							<?php snippet('layouts/menu-items', [
+								'items' => [
+									'For developers' => page('features/developers'),
+									'For designers' => page('features/designers'),
+									'For content creators' => page('features/creators'),
+									'For clients & agencies' => page('features/clients'),
+									'Showcase' => page('love'),
+									'Releases' => page('releases'),
+									'Feedback' => 'https://feedback.getkirby.com',
+								]
+							]) ?>
 						</ul>
 					</li>
 					<li>
 						<p class="font-bold mb-1">Docs</p>
 						<ul class="footer-menu-2">
-							<li><a href="<?= page('docs/guide')->menuUrl() ?>">Guide</a></li>
-							<li><a href="<?= page('docs/reference')->menuUrl() ?>">Reference</a></li>
-							<li><a href="<?= page('docs/cookbook')->menuUrl() ?>">Cookbook</a></li>
-							<li><a href="<?= page('docs/quicktips')->menuUrl() ?>">Quicktips</a></li>
-							<li><a href="https://videos.getkirby.com">Screencasts</a></li>
-							<li><a href="<?= page('docs/glossary')->menuUrl() ?>">Glossary</a></li>
-							<li><a href="<?= page('docs/archive')->menuUrl() ?>">Archive</a></li>
+							<?php snippet('layouts/menu-items', [
+								'items' => [
+									'Guide' => page('docs/guide'),
+									'Reference' => page('docs/reference'),
+									'Cookbook' => page('docs/cookbook'),
+									'Quicktips' => page('docs/quicktips'),
+									'Screencasts' => 'https://www.youtube.com/kirbycasts',
+									'Glossary' => page('docs/glossary'),
+									'Archive' => page('docs/archive'),
+								]
+							]) ?>
 						</ul>
 					</li>
 					<li>
 						<p class="font-bold mb-1">Resources</p>
 						<ul class="footer-menu-2">
-							<li><a href="https://plugins.getkirby.com">Plugins</a></li>
-							<li><a href="<?= page('themes')->menuUrl() ?>">Themes</a></li>
-							<li><a href="<?= page('kosmos')->menuUrl() ?>">Newsletter</a></li>
-							<li><a href="<?= page('buzz')->menuUrl() ?>">Buzz</a></li>
-							<li><a href="https://hub.getkirby.com">License Hub</a></li>
+							<?php snippet('layouts/menu-items', [
+								'items' => [
+									'Plugins' => 'https://plugins.getkirby.com',
+									'Themes' => page('themes'),
+									'Newsletter' => page('kosmos'),
+									'Buzz' => page('buzz'),
+									'License Hub' => 'https://hub.getkirby.com',
+								]
+							]) ?>
 						</ul>
 					</li>
 					<li>
 						<p class="font-bold mb-1">Community</p>
 						<ul class="footer-menu-2">
-							<li><a href="<?= page('meet')->menuUrl() ?>">Get together</a></li>
-							<li><a href="https://forum.getkirby.com">Support forum</a></li>
-							<li><a href="https://chat.getkirby.com">Discord chat</a></li>
-							<li><a href="https://community.getkirby.com">Community map</a></li>
-							<li><a href="https://mastodon.social/@getkirby">Mastodon</a></li>
-							<li><a href="https://www.linkedin.com/company/getkirby">LinkedIn</a></li>
-							<li><a href="https://instagram.com/getkirby">Instagram</a></li>
+							<?php snippet('layouts/menu-items', [
+								'items' => [
+									'Get together' => page('meet'),
+									'Support forum' => 'https://forum.getkirby.com',
+									'Discord chat' => 'https://chat.getkirby.com',
+									'Community map' => 'https://community.getkirby.com',
+									'Mastodon' => 'https://mastodon.social/@getkirby',
+									'LinkedIn' => 'https://www.linkedin.com/company/getkirby',
+									'Instagram' => 'https://instagram.com/getkirby',
+								]
+							]) ?>
 						</ul>
 					</li>
 					<li>
 						<p class="font-bold mb-1">Kirby</p>
 						<ul class="footer-menu-2">
-							<li><a href="<?= page('security')->menuUrl() ?>">Security</a></li>
-							<li><a href="<?= page('privacy')->menuUrl() ?>">Privacy</a></li>
-							<li><a href="<?= page('license')->menuUrl() ?>">License</a></li>
-							<li><a href="<?= page('press')->menuUrl() ?>">Presskit</a></li>
-							<li><a href="<?= page('contact')->menuUrl() ?>">Contact</a></li>
+							<?php snippet('layouts/menu-items', [
+								'items' => [
+									'Security' => page('security'),
+									'Privacy' => page('privacy'),
+									'License' => page('license'),
+									'Presskit' => page('press'),
+									'Contact' => page('contact'),
+								]
+							]) ?>
 						</ul>
 					</li>
 					<li>

--- a/site/snippets/layouts/footer.php
+++ b/site/snippets/layouts/footer.php
@@ -34,41 +34,41 @@
 					<li>
 						<p class="font-bold mb-1">The CMS</p>
 						<ul class="footer-menu-2">
-							<li><a href="/features/developers">For developers</a></li>
-							<li><a href="/features/designers">For designers</a></li>
-							<li><a href="/features/creators">For content creators</a></li>
-							<li><a href="/features/clients">For clients & agencies</a></li>
-							<li><a href="/love">Showcase</a></li>
-							<li><a href="/releases">Releases</a></li>
+							<li><a href="<?= page('features/developers')->menuUrl() ?>">For developers</a></li>
+							<li><a href="<?= page('features/designers')->menuUrl() ?>">For designers</a></li>
+							<li><a href="<?= page('features/creators')->menuUrl() ?>">For content creators</a></li>
+							<li><a href="<?= page('features/clients')->menuUrl() ?>">For clients & agencies</a></li>
+							<li><a href="<?= page('love')->menuUrl() ?>">Showcase</a></li>
+							<li><a href="<?= page('releases')->menuUrl() ?>">Releases</a></li>
 							<li><a href="https://feedback.getkirby.com">Feedback</a></li>
 						</ul>
 					</li>
 					<li>
 						<p class="font-bold mb-1">Docs</p>
 						<ul class="footer-menu-2">
-							<li><a href="/docs/guide">Guide</a></li>
-							<li><a href="/docs/reference">Reference</a></li>
-							<li><a href="/docs/cookbook">Cookbook</a></li>
-							<li><a href="/docs/quicktips">Quicktips</a></li>
+							<li><a href="<?= page('docs/guide')->menuUrl() ?>">Guide</a></li>
+							<li><a href="<?= page('docs/reference')->menuUrl() ?>">Reference</a></li>
+							<li><a href="<?= page('docs/cookbook')->menuUrl() ?>">Cookbook</a></li>
+							<li><a href="<?= page('docs/quicktips')->menuUrl() ?>">Quicktips</a></li>
 							<li><a href="https://videos.getkirby.com">Screencasts</a></li>
-							<li><a href="/docs/glossary">Glossary</a></li>
-							<li><a href="/docs/archive">Archive</a></li>
+							<li><a href="<?= page('docs/glossary')->menuUrl() ?>">Glossary</a></li>
+							<li><a href="<?= page('docs/archive')->menuUrl() ?>">Archive</a></li>
 						</ul>
 					</li>
 					<li>
 						<p class="font-bold mb-1">Resources</p>
 						<ul class="footer-menu-2">
 							<li><a href="https://plugins.getkirby.com">Plugins</a></li>
-							<li><a href="/themes">Themes</a></li>
-							<li><a href="/kosmos">Newsletter</a></li>
-							<li><a href="/buzz">Buzz</a></li>
+							<li><a href="<?= page('themes')->menuUrl() ?>">Themes</a></li>
+							<li><a href="<?= page('kosmos')->menuUrl() ?>">Newsletter</a></li>
+							<li><a href="<?= page('buzz')->menuUrl() ?>">Buzz</a></li>
 							<li><a href="https://hub.getkirby.com">License Hub</a></li>
 						</ul>
 					</li>
 					<li>
 						<p class="font-bold mb-1">Community</p>
 						<ul class="footer-menu-2">
-							<li><a href="/meet">Get together</a></li>
+							<li><a href="<?= page('meet')->menuUrl() ?>">Get together</a></li>
 							<li><a href="https://forum.getkirby.com">Support forum</a></li>
 							<li><a href="https://chat.getkirby.com">Discord chat</a></li>
 							<li><a href="https://community.getkirby.com">Community map</a></li>
@@ -80,11 +80,11 @@
 					<li>
 						<p class="font-bold mb-1">Kirby</p>
 						<ul class="footer-menu-2">
-							<li><a href="/security">Security</a></li>
-							<li><a href="/privacy">Privacy</a></li>
-							<li><a href="/license">License</a></li>
-							<li><a href="/press">Presskit</a></li>
-							<li><a href="/contact">Contact</a></li>
+							<li><a href="<?= page('security')->menuUrl() ?>">Security</a></li>
+							<li><a href="<?= page('privacy')->menuUrl() ?>">Privacy</a></li>
+							<li><a href="<?= page('license')->menuUrl() ?>">License</a></li>
+							<li><a href="<?= page('press')->menuUrl() ?>">Presskit</a></li>
+							<li><a href="<?= page('contact')->menuUrl() ?>">Contact</a></li>
 						</ul>
 					</li>
 					<li>

--- a/site/snippets/layouts/menu-items.php
+++ b/site/snippets/layouts/menu-items.php
@@ -2,7 +2,7 @@
 	<?php if ($target instanceof \Kirby\Cms\Page): ?>
 	<li><a href="<?= $target->menuUrl() ?>"><?= $label ?></a></li>
 	<?php elseif (is_string($label) === true): ?>
-	<li><a <?php if ($externalClass ?? null): ?>class="<?= $externalClass ?>" <?php endif ?>href="<?= $target ?>"><?= $label ?></a></li>
+	<li><a <?= e($externalClass ?? null, 'class="' . $externalClass . '" ') ?>href="<?= $target ?>"><?= $label ?></a></li>
 	<?php else: ?>
 	<li><hr /></li>
 	<?php endif ?>

--- a/site/snippets/layouts/menu-items.php
+++ b/site/snippets/layouts/menu-items.php
@@ -1,0 +1,9 @@
+<?php foreach ($items as $label => $target): ?>
+	<?php if ($target instanceof \Kirby\Cms\Page): ?>
+	<li><a href="<?= $target->menuUrl() ?>"><?= $label ?></a></li>
+	<?php elseif (is_string($label) === true): ?>
+	<li><a <?php if ($externalClass ?? null): ?>class="<?= $externalClass ?>" <?php endif ?>href="<?= $target ?>"><?= $label ?></a></li>
+	<?php else: ?>
+	<li><hr /></li>
+	<?php endif ?>
+<?php endforeach ?>

--- a/site/snippets/layouts/menu-items.php
+++ b/site/snippets/layouts/menu-items.php
@@ -2,7 +2,7 @@
 	<?php if ($target instanceof \Kirby\Cms\Page): ?>
 	<li><a href="<?= $target->menuUrl() ?>"><?= $label ?></a></li>
 	<?php elseif (is_string($label) === true): ?>
-	<li><a <?= e($externalClass ?? null, 'class="' . ($externalClass ?? '') . '" ') ?>href="<?= $target ?>"><?= $label ?></a></li>
+	<li><a class="is-external" href="<?= $target ?>"><?= $label ?></a></li>
 	<?php else: ?>
 	<li><hr /></li>
 	<?php endif ?>

--- a/site/snippets/layouts/menu-items.php
+++ b/site/snippets/layouts/menu-items.php
@@ -2,7 +2,7 @@
 	<?php if ($target instanceof \Kirby\Cms\Page): ?>
 	<li><a href="<?= $target->menuUrl() ?>"><?= $label ?></a></li>
 	<?php elseif (is_string($label) === true): ?>
-	<li><a <?= e($externalClass ?? null, 'class="' . $externalClass . '" ') ?>href="<?= $target ?>"><?= $label ?></a></li>
+	<li><a <?= e($externalClass ?? null, 'class="' . ($externalClass ?? '') . '" ') ?>href="<?= $target ?>"><?= $label ?></a></li>
 	<?php else: ?>
 	<li><hr /></li>
 	<?php endif ?>

--- a/site/snippets/layouts/menu.php
+++ b/site/snippets/layouts/menu.php
@@ -6,46 +6,46 @@
 	<nav aria-label="Main menu">
 		<ul class="menu-1">
 			<li class="has-submenu">
-				<a href="/features/developers">The CMS</a>
+				<a href="<?= page('features/developers')->menuUrl() ?>">The CMS</a>
 				<ul class="menu-2">
-					<li><a href="/features/developers">For developers</a></li>
-					<li><a href="/features/designers">For designers</a></li>
-					<li><a href="/features/creators">For content creators</a></li>
-					<li><a href="/features/clients">For clients & agencies</a></li>
+					<li><a href="<?= page('features/developers')->menuUrl() ?>">For developers</a></li>
+					<li><a href="<?= page('features/designers')->menuUrl() ?>">For designers</a></li>
+					<li><a href="<?= page('features/creators')->menuUrl() ?>">For content creators</a></li>
+					<li><a href="<?= page('features/clients')->menuUrl() ?>">For clients & agencies</a></li>
 					<li><hr /></li>
-					<li><a href="/love">Showcase</a></li>
-					<li><a href="/releases">Releases</a></li>
+					<li><a href="<?= page('love')->menuUrl() ?>">Showcase</a></li>
+					<li><a href="<?= page('releases')->menuUrl() ?>">Releases</a></li>
 					<li><a class="is-external" href="https://feedback.getkirby.com">Feedback</a></li>
 				</ul>
 			</li>
 			<li class="has-submenu">
-				<a href="/docs/guide">Docs</a>
+				<a href="<?= page('docs/guide')->menuUrl() ?>">Docs</a>
 				<ul class="menu-2">
-					<li><a href="/docs/guide">Guide</a></li>
-					<li><a href="/docs/reference">Reference</a></li>
+					<li><a href="<?= page('docs/guide')->menuUrl() ?>">Guide</a></li>
+					<li><a href="<?= page('docs/reference')->menuUrl() ?>">Reference</a></li>
 
-					<li><a href="/docs/cookbook">Cookbook</a></li>
-					<li><a href="/docs/quicktips">Quicktips</a></li>
+					<li><a href="<?= page('docs/cookbook')->menuUrl() ?>">Cookbook</a></li>
+					<li><a href="<?= page('docs/quicktips')->menuUrl() ?>">Quicktips</a></li>
 					<li><a class="is-external" href="https://youtube.com/kirbycasts">Screencasts</a></li>
-					<li><a href="/docs/glossary">Glossary</a></li>
+					<li><a href="<?= page('docs/glossary')->menuUrl() ?>">Glossary</a></li>
 				</ul>
 			</li>
 			<li class="has-submenu">
-				<a href="/kosmos">Resources</a>
+				<a href="<?= page('kosmos')->menuUrl() ?>">Resources</a>
 				<ul class="menu-2">
 					<li><a class="is-external" href="https://plugins.getkirby.com">Plugins</a></li>
-					<li><a href="/themes">Themes</a></li>
+					<li><a href="<?= page('themes')->menuUrl() ?>">Themes</a></li>
 					<li><hr /></li>
-					<li><a href="/kosmos">Newsletter</a></li>
-					<li><a href="/buzz">Buzz</a></li>
+					<li><a href="<?= page('kosmos')->menuUrl() ?>">Newsletter</a></li>
+					<li><a href="<?= page('buzz')->menuUrl() ?>">Buzz</a></li>
 					<li><hr /></li>
 					<li><a class="is-external" href="https://hub.getkirby.com">License Hub</a></li>
 				</ul>
 			</li>
 			<li class="has-submenu">
-				<a href="/meet">Community</a>
+				<a href="<?= page('meet')->menuUrl() ?>">Community</a>
 				<ul class="menu-2">
-					<li><a href="/meet">Get together</a></li>
+					<li><a href="<?= page('meet')->menuUrl() ?>">Get together</a></li>
 					<li><hr /></li>
 					<li><a class="is-external" href="https://forum.getkirby.com">Support forum</a></li>
 					<li><a class="is-external" href="https://chat.getkirby.com">Discord chat</a></li>
@@ -56,17 +56,17 @@
 					<li><a class="is-external" href="https://instagram.com/getkirby">Instagram</a></li>
 				</ul>
 			</li>
-			<li><a class="partners" href="/partners">Partners</a></li>
+			<li><a class="partners" href="<?= page('partners')->menuUrl() ?>">Partners</a></li>
 		</ul>
 		<ul class="menu-1 menu-steps">
-			<li><a href="/try">Try</a></li>
+			<li><a href="<?= page('try')->menuUrl() ?>">Try</a></li>
 			<li>
-				<a href="/love" aria-label="Love">
+				<a href="<?= page('love')->menuUrl() ?>" aria-label="Love">
 					<?= icon('heart') ?>
 				</a>
 			</li>
 			<li>
-				<a href="/buy">Buy</a>
+				<a href="<?= page('buy')->menuUrl() ?>">Buy</a>
 			</li>
 		</ul>
 	</nav>

--- a/site/snippets/layouts/menu.php
+++ b/site/snippets/layouts/menu.php
@@ -15,7 +15,7 @@
 							'For designers' => page('features/designers'),
 							'For content creators' => page('features/creators'),
 							'For clients & agencies' => page('features/clients'),
-							'hr',
+							'-',
 							'Showcase' => page('love'),
 							'Releases' => page('releases'),
 							'Feedback' => 'https://feedback.getkirby.com',
@@ -47,10 +47,10 @@
 						'items' => [
 							'Plugins' => 'https://plugins.getkirby.com',
 							'Themes' => page('themes'),
-							'hr',
+							'-',
 							'Newsletter' => page('kosmos'),
 							'Buzz' => page('buzz'),
-							'hr',
+							'-',
 							'License Hub' => 'https://hub.getkirby.com',
 						]
 					]) ?>
@@ -63,11 +63,11 @@
 						'externalClass' => 'is-external',
 						'items' => [
 							'Get together' => page('meet'),
-							'hr',
+							'-',
 							'Support forum' => 'https://forum.getkirby.com',
 							'Discord chat' => 'https://chat.getkirby.com',
 							'Community map' => 'https://community.getkirby.com',
-							'hr',
+							'-',
 							'Mastodon' => 'https://mastodon.social/@getkirby',
 							'LinkedIn' => 'https://www.linkedin.com/company/getkirby',
 							'Instagram' => 'https://instagram.com/getkirby',

--- a/site/snippets/layouts/menu.php
+++ b/site/snippets/layouts/menu.php
@@ -8,52 +8,71 @@
 			<li class="has-submenu">
 				<a href="<?= page('features/developers')->menuUrl() ?>">The CMS</a>
 				<ul class="menu-2">
-					<li><a href="<?= page('features/developers')->menuUrl() ?>">For developers</a></li>
-					<li><a href="<?= page('features/designers')->menuUrl() ?>">For designers</a></li>
-					<li><a href="<?= page('features/creators')->menuUrl() ?>">For content creators</a></li>
-					<li><a href="<?= page('features/clients')->menuUrl() ?>">For clients & agencies</a></li>
-					<li><hr /></li>
-					<li><a href="<?= page('love')->menuUrl() ?>">Showcase</a></li>
-					<li><a href="<?= page('releases')->menuUrl() ?>">Releases</a></li>
-					<li><a class="is-external" href="https://feedback.getkirby.com">Feedback</a></li>
+					<?php snippet('layouts/menu-items', [
+						'externalClass' => 'is-external',
+						'items' => [
+							'For developers' => page('features/developers'),
+							'For designers' => page('features/designers'),
+							'For content creators' => page('features/creators'),
+							'For clients & agencies' => page('features/clients'),
+							'hr',
+							'Showcase' => page('love'),
+							'Releases' => page('releases'),
+							'Feedback' => 'https://feedback.getkirby.com',
+						]
+					]) ?>
 				</ul>
 			</li>
 			<li class="has-submenu">
 				<a href="<?= page('docs/guide')->menuUrl() ?>">Docs</a>
 				<ul class="menu-2">
-					<li><a href="<?= page('docs/guide')->menuUrl() ?>">Guide</a></li>
-					<li><a href="<?= page('docs/reference')->menuUrl() ?>">Reference</a></li>
-
-					<li><a href="<?= page('docs/cookbook')->menuUrl() ?>">Cookbook</a></li>
-					<li><a href="<?= page('docs/quicktips')->menuUrl() ?>">Quicktips</a></li>
-					<li><a class="is-external" href="https://youtube.com/kirbycasts">Screencasts</a></li>
-					<li><a href="<?= page('docs/glossary')->menuUrl() ?>">Glossary</a></li>
+					<?php snippet('layouts/menu-items', [
+						'externalClass' => 'is-external',
+						'items' => [
+							'Guide' => page('docs/guide'),
+							'Reference' => page('docs/reference'),
+							'Cookbook' => page('docs/cookbook'),
+							'Quicktips' => page('docs/quicktips'),
+							'Screencasts' => 'https://www.youtube.com/kirbycasts',
+							'Glossary' => page('docs/glossary'),
+						]
+					]) ?>
 				</ul>
 			</li>
 			<li class="has-submenu">
 				<a href="<?= page('kosmos')->menuUrl() ?>">Resources</a>
 				<ul class="menu-2">
-					<li><a class="is-external" href="https://plugins.getkirby.com">Plugins</a></li>
-					<li><a href="<?= page('themes')->menuUrl() ?>">Themes</a></li>
-					<li><hr /></li>
-					<li><a href="<?= page('kosmos')->menuUrl() ?>">Newsletter</a></li>
-					<li><a href="<?= page('buzz')->menuUrl() ?>">Buzz</a></li>
-					<li><hr /></li>
-					<li><a class="is-external" href="https://hub.getkirby.com">License Hub</a></li>
+					<?php snippet('layouts/menu-items', [
+						'externalClass' => 'is-external',
+						'items' => [
+							'Plugins' => 'https://plugins.getkirby.com',
+							'Themes' => page('themes'),
+							'hr',
+							'Newsletter' => page('kosmos'),
+							'Buzz' => page('buzz'),
+							'hr',
+							'License Hub' => 'https://hub.getkirby.com',
+						]
+					]) ?>
 				</ul>
 			</li>
 			<li class="has-submenu">
 				<a href="<?= page('meet')->menuUrl() ?>">Community</a>
 				<ul class="menu-2">
-					<li><a href="<?= page('meet')->menuUrl() ?>">Get together</a></li>
-					<li><hr /></li>
-					<li><a class="is-external" href="https://forum.getkirby.com">Support forum</a></li>
-					<li><a class="is-external" href="https://chat.getkirby.com">Discord chat</a></li>
-					<li><a class="is-external" href="https://community.getkirby.com">Community map</a></li>
-					<li><hr /></li>
-					<li><a class="is-external" href="https://mastodon.social/@getkirby">Mastodon</a></li>
-					<li><a class="is-external" href="https://www.linkedin.com/company/getkirby">LinkedIn</a></li>
-					<li><a class="is-external" href="https://instagram.com/getkirby">Instagram</a></li>
+					<?php snippet('layouts/menu-items', [
+						'externalClass' => 'is-external',
+						'items' => [
+							'Get together' => page('meet'),
+							'hr',
+							'Support forum' => 'https://forum.getkirby.com',
+							'Discord chat' => 'https://chat.getkirby.com',
+							'Community map' => 'https://community.getkirby.com',
+							'hr',
+							'Mastodon' => 'https://mastodon.social/@getkirby',
+							'LinkedIn' => 'https://www.linkedin.com/company/getkirby',
+							'Instagram' => 'https://instagram.com/getkirby',
+						]
+					]) ?>
 				</ul>
 			</li>
 			<li><a class="partners" href="<?= page('partners')->menuUrl() ?>">Partners</a></li>

--- a/site/snippets/layouts/menu.php
+++ b/site/snippets/layouts/menu.php
@@ -9,7 +9,6 @@
 				<a href="<?= page('features/developers')->menuUrl() ?>">The CMS</a>
 				<ul class="menu-2">
 					<?php snippet('layouts/menu-items', [
-						'externalClass' => 'is-external',
 						'items' => [
 							'For developers' => page('features/developers'),
 							'For designers' => page('features/designers'),
@@ -27,7 +26,6 @@
 				<a href="<?= page('docs/guide')->menuUrl() ?>">Docs</a>
 				<ul class="menu-2">
 					<?php snippet('layouts/menu-items', [
-						'externalClass' => 'is-external',
 						'items' => [
 							'Guide' => page('docs/guide'),
 							'Reference' => page('docs/reference'),
@@ -43,7 +41,6 @@
 				<a href="<?= page('kosmos')->menuUrl() ?>">Resources</a>
 				<ul class="menu-2">
 					<?php snippet('layouts/menu-items', [
-						'externalClass' => 'is-external',
 						'items' => [
 							'Plugins' => 'https://plugins.getkirby.com',
 							'Themes' => page('themes'),
@@ -60,7 +57,6 @@
 				<a href="<?= page('meet')->menuUrl() ?>">Community</a>
 				<ul class="menu-2">
 					<?php snippet('layouts/menu-items', [
-						'externalClass' => 'is-external',
 						'items' => [
 							'Get together' => page('meet'),
 							'-',

--- a/site/snippets/sidebar/menu.php
+++ b/site/snippets/sidebar/menu.php
@@ -10,7 +10,7 @@ extract([
 		<?php if ($menuItem->hasListedChildren()): ?>
 		<details class="details" <?= $open || $menuItem->isOpen() ? 'open' : '' ?>>
 			<summary>
-				<a <?= ariaCurrent($menuItem->isActive(), 'page') ?> href="<?= $menuItem->url() ?>"><?= $menuItem->title() ?></a>
+				<a <?= ariaCurrent($menuItem->isActiveInMenu(hasSubmenu: true), 'page') ?> href="<?= $menuItem->menuUrl() ?>"><?= $menuItem->title() ?></a>
 			</summary>
 
 			<ul class="sidebar-menu-2">
@@ -19,7 +19,7 @@ extract([
 					<?php if ($submenuItem->intendedTemplate()->name() === 'separator'): ?>
 					<hr>
 					<?php else: ?>
-					<a <?= ariaCurrent($submenuItem->isOpen(), 'page') ?> href="<?= $submenuItem->url() ?>"><?= $submenuItem->title() ?></a>
+					<a <?= ariaCurrent($submenuItem->isActiveInMenu(), 'page') ?> href="<?= $submenuItem->menuUrl() ?>"><?= $submenuItem->title() ?></a>
 					<?php endif ?>
 				</li>
 				<?php endforeach ?>
@@ -27,7 +27,7 @@ extract([
 		</details>
 
 		<?php else: ?>
-		<a <?= ariaCurrent($menuItem->isActive(), 'page') ?> href="<?= $menuItem->url() ?>"><?= $menuItem->title() ?></a>
+		<a <?= ariaCurrent($menuItem->isActiveInMenu(), 'page') ?> href="<?= $menuItem->menuUrl() ?>"><?= $menuItem->title() ?></a>
 		<?php endif ?>
 	</li>
 	<?php endforeach ?>

--- a/site/snippets/sidebar/menu.php
+++ b/site/snippets/sidebar/menu.php
@@ -10,7 +10,7 @@ extract([
 		<?php if ($menuItem->hasListedChildren()): ?>
 		<details class="details" <?= $open || $menuItem->isOpen() ? 'open' : '' ?>>
 			<summary>
-				<a <?= ariaCurrent($menuItem->isActiveInMenu(hasSubmenu: true), 'page') ?> href="<?= $menuItem->menuUrl() ?>"><?= $menuItem->title() ?></a>
+				<a <?= ariaCurrent($menuItem->isActive(hasSubmenu: true), 'page') ?> href="<?= $menuItem->menuUrl() ?>"><?= $menuItem->title() ?></a>
 			</summary>
 
 			<ul class="sidebar-menu-2">
@@ -27,7 +27,7 @@ extract([
 		</details>
 
 		<?php else: ?>
-		<a <?= ariaCurrent($menuItem->isActiveInMenu(), 'page') ?> href="<?= $menuItem->menuUrl() ?>"><?= $menuItem->title() ?></a>
+		<a <?= ariaCurrent($menuItem->isActive(), 'page') ?> href="<?= $menuItem->menuUrl() ?>"><?= $menuItem->title() ?></a>
 		<?php endif ?>
 	</li>
 	<?php endforeach ?>

--- a/site/snippets/sidebar/menu.php
+++ b/site/snippets/sidebar/menu.php
@@ -19,7 +19,7 @@ extract([
 					<?php if ($submenuItem->intendedTemplate()->name() === 'separator'): ?>
 					<hr>
 					<?php else: ?>
-					<a <?= ariaCurrent($submenuItem->isActiveInMenu(), 'page') ?> href="<?= $submenuItem->menuUrl() ?>"><?= $submenuItem->title() ?></a>
+					<a <?= ariaCurrent($submenuItem->isOpen(), 'page') ?> href="<?= $submenuItem->menuUrl() ?>"><?= $submenuItem->title() ?></a>
 					<?php endif ?>
 				</li>
 				<?php endforeach ?>

--- a/site/templates/glossary-entry.php
+++ b/site/templates/glossary-entry.php
@@ -1,1 +1,1 @@
-<?php go($page->link()->or($page->url()));
+<?php go($page->menuUrl());

--- a/site/templates/guide.php
+++ b/site/templates/guide.php
@@ -3,7 +3,7 @@
 <?php slot('sidebar') ?>
 <?php snippet('sidebar', [
 	'title'         => 'Guide',
-	'link'          => '/docs/guide',
+	'link'          => page('docs/guide')->menuUrl(),
 	'menu'          => $menu,
 	'hasCategories' => true,
 ]) ?>

--- a/site/templates/guides.php
+++ b/site/templates/guides.php
@@ -1,1 +1,1 @@
-<?php go(collection('guides')->first());
+<?php go($page->menuUrl());

--- a/site/templates/legacy.php
+++ b/site/templates/legacy.php
@@ -1,3 +1,1 @@
-<?php
-
-go($page->src());
+<?php go($page->src());

--- a/site/templates/link.php
+++ b/site/templates/link.php
@@ -1,3 +1,1 @@
-<?php
-
-go($page->link());
+<?php go($page->link());

--- a/site/templates/theme-developer.php
+++ b/site/templates/theme-developer.php
@@ -1,1 +1,1 @@
-<?php go($page->parent()->url());
+<?php go($page->menuUrl());


### PR DESCRIPTION
Some of our templates redirect to another page (e.g. child page). If we include those pages in menus, the user needs to be redirected even though we already know the final target. This is currently mostly the case with `docs/guide` and `license`.

This PR implements two new page methods:

- `menuUrl()`: Returns the final URL after redirects to be used in menus. Overridden in the page model where relevant, otherwise falls back to the page URL.
- `isActiveInMenu()`: Variant of `isActive()` that respects `menuUrl()`. This fixes a bug in the menu for legal pages where the [License page](https://getkirby.com/license) wouldn't show an active state because it immediately redirects to its last child.