### PR TITLE
`srcset` refactoring

### DIFF
--- a/site/plugins/site/helpers/html.php
+++ b/site/plugins/site/helpers/html.php
@@ -67,6 +67,7 @@ function img($file, array $props = [])
 		'alt'     => $props['alt'] ?? '',
 		'class'   => $props['class'] ?? null,
 		'loading' => $loading ?? null,
+		'sizes'   => $props['sizes'] ?? null,
 		'src'     => $src,
 		'srcset'  => $srcset,
 		'width'   => $file->width(),

--- a/site/templates/partner.php
+++ b/site/templates/partner.php
@@ -49,7 +49,21 @@
 <div class="partner-grid columns mb-24">
 	<figure style="--aspect-ratio: 3/2;" class="partner-hero mb-3">
 		<?php if ($image = $page->card()): ?>
-			<?= $image->resize(1600) ?>
+			<?= img($image, [
+				'alt' => '',
+				'src' => [
+					'width' => 1000
+				],
+				'lazy' => false,
+				'sizes' => '(max-width: 1020px) 90vw, 55vw',
+				'srcset' => [
+					300,
+					500,
+					768,
+					1000,
+					1536
+				]
+			]) ?>
 		<?php elseif ($image = $page->avatar()): ?>
 			<span class="p-6 bg-light">
 				<img
@@ -130,7 +144,19 @@
 							<a href="<?= $project->link() ?>" target="_blank">
 								<div style="--aspect-ratio: 3/4" class="bg-light mb-6 shadow-lg">
 									<?php if ($image = $project->image()): ?>
-										<?= $image->name() === 'example' ? $image : $image->resize(800) ?>
+										<?= $image->name() === 'example' ? $image : img($image, [
+											'alt' => '',
+											'src' => [
+												'width' => 702
+											],
+											'sizes' => '(max-width: 640px) 85vw, 25vw',
+											'srcset' => [
+												352,
+												550,
+												702,
+												1100,
+											]
+										]) ?>
 									<?php endif ?>
 								</div>
 								<figcaption class="font-mono text-sm mb-3">


### PR DESCRIPTION
I noticed that we don't use the `srcset` attribute on the partner pages at all yet. This causes a performance bottleneck on those pages as the loaded images are commonly way too large.

This PR:

- adds `srcset` support to the partner template and
- introduces `sizes` support for our `img` helper.

So far we don't use `sizes` much and I think in many places we don't really need to, but I think especially for the images in columns like here on the partner page and on the love page, it could be useful because the browser otherwise defaults to loading an image for `100vw`.

In a later step we could then review all image uses on whether `sizes` is needed.