### PR TITLE
Additional performance improvements for home playground

### DIFF
--- a/assets/css/layouts/home.css
+++ b/assets/css/layouts/home.css
@@ -87,7 +87,7 @@
 .playground-header-figure {
 	position: relative;
 	z-index: 1;
-	background: var(--color-light);
+	background: var(--color-dark);
 	overflow: hidden;
 }
 .playground-header-figure-wrapper {

--- a/assets/css/layouts/home.css
+++ b/assets/css/layouts/home.css
@@ -87,17 +87,15 @@
 .playground-header-figure {
 	position: relative;
 	z-index: 1;
-}
-.playground-header-figure-wrapper {
-	display: block;
 	background: var(--color-light);
 	overflow: hidden;
 }
-.playground-header-figure-wrapper img {
+.playground-header-figure-wrapper {
+	display: block;
 	opacity: 1;
 	transition: opacity 0.4s;
 }
-.playground-header-figure-wrapper.loading img {
+.playground-header-figure-wrapper.loading {
 	opacity: 0;
 	transition: opacity 0.2s;
 }
@@ -134,7 +132,7 @@
 
 /** Large */
 @media screen and (min-width: 50rem) {
-	.playground-header-figure-wrapper {
+	.playground-header-figure {
 		border-top-right-radius: var(--spacing-2);
 		border-bottom-right-radius: var(--spacing-2);
 	}
@@ -142,7 +140,7 @@
 
 /** Huge */
 @media screen and (min-width: 110.1rem) {
-	.playground-header-figure-wrapper {
+	.playground-header-figure {
 		border-radius: var(--spacing-2);
 	}
 }

--- a/assets/css/layouts/home.css
+++ b/assets/css/layouts/home.css
@@ -87,7 +87,7 @@
 .playground-header-figure {
 	position: relative;
 	z-index: 1;
-	background: var(--color-dark);
+	background: var(--color-light);
 	overflow: hidden;
 }
 .playground-header-figure-wrapper {

--- a/assets/js/layouts/playground.js
+++ b/assets/js/layouts/playground.js
@@ -28,8 +28,7 @@ export class Playground {
 
 	async switchTo(link) {
 		// fade out the old image
-		this.$el
-			.querySelector(".playground-header-figure-wrapper")
+		this.currentWrapper()
 			.classList.add("loading");
 
 		// since our CSS transition to fade out the image takes 200ms,
@@ -43,8 +42,7 @@ export class Playground {
 		this.$el.innerHTML = doc.querySelector(".playground").innerHTML;
 
 		// fade in the image once loaded
-		this.$el
-			.querySelector(".playground-header-figure img")
+		this.currentImg()
 			.addEventListener("load", function () {
 				// let the browser render the image first to reduce flickering issues
 				setTimeout(() => this.parentNode.classList.remove("loading"), 10);
@@ -52,5 +50,13 @@ export class Playground {
 
 		// reactivate code highlighting
 		Prism.highlightAll();
+	}
+
+	currentWrapper() {
+		return this.$el.querySelector(".playground-header-figure-wrapper");
+	}
+
+	currentImg() {
+		return this.$el.querySelector(".playground-header-figure-wrapper img");
 	}
 }

--- a/assets/js/layouts/playground.js
+++ b/assets/js/layouts/playground.js
@@ -46,8 +46,8 @@ export class Playground {
 		this.$el
 			.querySelector(".playground-header-figure img")
 			.addEventListener("load", function () {
-				// use next tick to avoid flickering issues
-				setTimeout(() => this.parentNode.classList.remove("loading"), 0);
+				// let the browser render the image first to reduce flickering issues
+				setTimeout(() => this.parentNode.classList.remove("loading"), 10);
 			});
 
 		// reactivate code highlighting

--- a/assets/js/layouts/playground.js
+++ b/assets/js/layouts/playground.js
@@ -12,6 +12,10 @@ export class Playground {
 		});
 	}
 
+	get image() {
+		return this.$el.querySelector(".playground-header-figure-wrapper img");
+	}
+
 	async loadHtml(link) {
 		const response = await fetch(link);
 		const body = await response.text();
@@ -64,9 +68,5 @@ export class Playground {
 
 	get wrapper() {
 		return this.$el.querySelector(".playground-header-figure-wrapper");
-	}
-
-	get image() {
-		return this.$el.querySelector(".playground-header-figure-wrapper img");
 	}
 }

--- a/assets/js/layouts/playground.js
+++ b/assets/js/layouts/playground.js
@@ -28,14 +28,13 @@ export class Playground {
 
 	async switchTo(link, target) {
 		// fade out the old image
-		this.currentWrapper()
-			.classList.add("loading");
+		this.wrapper.classList.add("loading");
 
 		// preload the new image
-		const imgSource = this.currentImg()
-			.currentSrc
-			.replace(this.currentWrapper().dataset.image, target.dataset.image);
-		new Image().src = imgSource;
+		new Image().src = this.image.currentSrc.replace(
+			this.wrapper.dataset.image, 
+			target.dataset.image
+		);
 
 		// since our CSS transition to fade out the image takes 200ms,
 		// ensure that we wait that long, even if the fetch request is faster
@@ -48,8 +47,7 @@ export class Playground {
 		this.$el.innerHTML = doc.querySelector(".playground").innerHTML;
 
 		// fade in the image once loaded
-		this.currentImg()
-			.addEventListener("load", function () {
+		this.image.addEventListener("load", function () {
 				// let the browser render the image first to reduce flickering issues
 				setTimeout(() => this.parentNode.classList.remove("loading"), 10);
 			});
@@ -58,11 +56,11 @@ export class Playground {
 		Prism.highlightAll();
 	}
 
-	currentWrapper() {
+	get wrapper() {
 		return this.$el.querySelector(".playground-header-figure-wrapper");
 	}
 
-	currentImg() {
+	get image() {
 		return this.$el.querySelector(".playground-header-figure-wrapper img");
 	}
 }

--- a/assets/js/layouts/playground.js
+++ b/assets/js/layouts/playground.js
@@ -7,7 +7,7 @@ export class Playground {
 
 			if (link) {
 				e.preventDefault();
-				this.switchTo(link);
+				this.switchTo(link, e.target);
 			}
 		});
 	}
@@ -26,10 +26,16 @@ export class Playground {
 		return doc;
 	}
 
-	async switchTo(link) {
+	async switchTo(link, target) {
 		// fade out the old image
 		this.currentWrapper()
 			.classList.add("loading");
+
+		// preload the new image
+		const imgSource = this.currentImg()
+			.currentSrc
+			.replace(this.currentWrapper().dataset.image, target.dataset.image);
+		new Image().src = imgSource;
 
 		// since our CSS transition to fade out the image takes 200ms,
 		// ensure that we wait that long, even if the fetch request is faster

--- a/assets/js/layouts/playground.js
+++ b/assets/js/layouts/playground.js
@@ -26,15 +26,21 @@ export class Playground {
 		return doc;
 	}
 
+	preload(target) {
+		const newUrl = this.image.currentSrc.replace(
+			this.wrapper.dataset.image,
+			target.dataset.image
+		);
+
+		new Image().src = newUrl;
+	}
+
 	async switchTo(link, target) {
 		// fade out the old image
 		this.wrapper.classList.add("loading");
 
 		// preload the new image
-		new Image().src = this.image.currentSrc.replace(
-			this.wrapper.dataset.image, 
-			target.dataset.image
-		);
+		this.preload(target);
 
 		// since our CSS transition to fade out the image takes 200ms,
 		// ensure that we wait that long, even if the fetch request is faster

--- a/site/snippets/templates/home/playground/header.php
+++ b/site/snippets/templates/home/playground/header.php
@@ -15,7 +15,11 @@
 	<div class="w-full">
 		<div class="playground-header-layout">
 			<figure class="playground-header-figure">
-				<span class="playground-header-figure-wrapper" style="--aspect-ratio: <?= $storyImage->width() . '/' . $storyImage->height() ?>">
+				<span
+					class="playground-header-figure-wrapper"
+					style="--aspect-ratio: <?= $storyImage->width() . '/' . $storyImage->height() ?>"
+					data-image="<?= $story->uid() . '/' . $storyImage->mediaHash() ?>"
+				>
 					<?= img($storyImage, [
 						'alt' => $storyImage->alt()->or('Panel screenshot for: ' . $story->title()),
 						'src' => [
@@ -35,7 +39,7 @@
 			<div class="playground-header-menu">
 				<ul class="font-mono text-sm pt-6 sticky" style="--top: var(--spacing-2)">
 					<?php foreach ($stories as $option): ?>
-					<li><a <?php e($story === $option, 'aria-current="true"') ?> href="?your=<?= $option->slug() ?>"><?= $option->title() ?></a></li>
+					<li><a <?php e($story === $option, 'aria-current="true"') ?> href="?your=<?= $option->slug() ?>" data-image="<?= $option->uid() . '/' . $option->images()->findBy('name', 'panel')->mediaHash() ?>"><?= $option->title() ?></a></li>
 					<?php endforeach ?>
 					<li><a class="font-bold more" href="/love">Your ideas &rarr;</a></li>
 				</ul>


### PR DESCRIPTION
## What was changed

- Move the styles for the main image one layer up so that the `img` itself doesn't need to be transitioned
- Introduce a slight delay before fading in the image after the DOM change and the image load event
- Give the frontend the parts of the media URL that change for each image so it can dynamically build the correct image URL (respecting the `srcset` variant the browser selected for the current image)

## Why was it changed

- Reduce flickering in Safari and Firefox, respectively (at least I can now reproduce the flickering issues much less often, even when simulating network delays)
- Reduce loading delay when the user switches to another playground item as the image can be loaded already while waiting for and parsing the HTML