### PR TITLE
Events: localize datetime for user's timezone

### DIFF
--- a/site/models/meet-events.php
+++ b/site/models/meet-events.php
@@ -18,7 +18,6 @@ class MeetEventsPage extends Page
 		$events   = $this->getData();
 
 		foreach ($events as $event) {
-			$timezone   = 'CET';
 			$children[] = [
 				'slug'     => Str::kebab($event['name']),
 				'num'      => 0,
@@ -28,8 +27,7 @@ class MeetEventsPage extends Page
 				'content'  => [
 					'title'    => $event['name'],
 					'link'     => $event['entity_metadata']['location'],
-					'date'     => Date::optional($event['scheduled_start_time'])->setTimezone(new DateTimeZone($timezone))->format('Y-m-d H:i:s'),
-					'timezone' => $timezone
+					'date'     => Date::optional($event['scheduled_start_time'])->setTimezone(new DateTimeZone('UCT'))->format('Y-m-d\TH:i:s\Z'),
 				]
 			];
 		}

--- a/site/models/meet-events.php
+++ b/site/models/meet-events.php
@@ -27,7 +27,7 @@ class MeetEventsPage extends Page
 				'content'  => [
 					'title'    => $event['name'],
 					'link'     => $event['entity_metadata']['location'],
-					'date'     => Date::optional($event['scheduled_start_time'])->setTimezone(new DateTimeZone('UCT'))->format('Y-m-d\TH:i:s\Z'),
+					'date'     => $event['scheduled_start_time'],
 				]
 			];
 		}

--- a/site/snippets/templates/meet/events.php
+++ b/site/snippets/templates/meet/events.php
@@ -29,7 +29,7 @@
 <script>
 class LocalizedDatetimeElement extends HTMLElement {
 	connectedCallback() {
-		this.utc = new Date(this.date);
+		this.utc = new Date(this.getAttribute("date"));
 		this.innerText = this.format(this.utc);
 	}
 

--- a/site/snippets/templates/meet/events.php
+++ b/site/snippets/templates/meet/events.php
@@ -17,7 +17,7 @@
 			<a href="<?= $event->link() ?>" class="flex items-center justify-between bg-white p-3 rounded shadow">
 				<h3 class="font-bold"><?= $event->title() ?></h3>
 				<p class="color-gray-700">
-					<localized-datetime><?= $event->date() ?></localized-datetime>
+					<localized-datetime date="<?= $event->date() ?>"><?= $event->date()->toDate('D j M, H:i T') ?></localized-datetime>
 				</p>
 			</a>
 		</li>
@@ -28,10 +28,10 @@
 
 <script>
 class LocalizedDatetimeElement extends HTMLElement {
-  connectedCallback() {
-		this.utc = new Date(this.innerText);
+	connectedCallback() {
+		this.utc = new Date(this.date);
 		this.innerText = this.format(this.utc);
-  }
+	}
 
 	format(datetime) {
 		return datetime.toLocaleString(undefined, {

--- a/site/snippets/templates/meet/events.php
+++ b/site/snippets/templates/meet/events.php
@@ -17,7 +17,7 @@
 			<a href="<?= $event->link() ?>" class="flex items-center justify-between bg-white p-3 rounded shadow">
 				<h3 class="font-bold"><?= $event->title() ?></h3>
 				<p class="color-gray-700">
-					<?= $event->date()->toDate('D j M, H:i') ?> <?= $event->timezone() ?>
+					<localized-datetime><?= $event->date() ?></localized-datetime>
 				</p>
 			</a>
 		</li>
@@ -25,6 +25,30 @@
 	</ul>
 	<?php endif ?>
 </section>
+
+<script>
+class LocalizedDatetimeElement extends HTMLElement {
+  connectedCallback() {
+		this.utc = new Date(this.innerText);
+		this.innerText = this.format(this.utc);
+  }
+
+	format(datetime) {
+		return datetime.toLocaleString(undefined, {
+			weekday: "short",
+			day: "numeric",
+			month: "long",
+			year: "numeric",
+			hour12: false,
+			hour: "2-digit",
+			minute: "2-digit",
+			timeZoneName: "short"
+		})
+	}
+}
+
+customElements.define("localized-datetime", LocalizedDatetimeElement);
+</script>
 
 <style>
 @media (max-width: 40rem) {


### PR DESCRIPTION
## Description
### This PR changes...
- Event datetime is stored  in content as raw format retrieved from Discord API
- Adds custom HTML element `<localized-datetime>` which converts its UTC content to a localized string based on the user's timezone

<img width="1252" alt="Screenshot 2024-06-02 at 19 56 04" src="https://github.com/getkirby/getkirby.com/assets/3788865/43dc1fd4-1cee-4596-8f6a-d913f43cf36e">


### Reason
Replaces the hardcoded `CET` timezone that currently would display times by 1 hour offset (as we are in CEST now).
- https://github.com/getkirby/getkirby.com/issues/2324
