### PR TITLE
`FileVersion` for `cdn` plugin

### DIFF
--- a/site/plugins/cdn/index.php
+++ b/site/plugins/cdn/index.php
@@ -3,12 +3,13 @@
 include_once __DIR__ . '/helpers.php';
 
 load([
-	'kirby\\cdn\\optimizer' => __DIR__ . '/src/Optimizer.php'
+	'kirby\\cdn\\fileversion' => __DIR__ . '/src/FileVersion.php',
+	'kirby\\cdn\\optimizer'   => __DIR__ . '/src/Optimizer.php'
 ]);
 
+use Kirby\Cdn\FileVersion;
 use Kirby\Cdn\Optimizer;
 use Kirby\Cms\App;
-use Kirby\Cms\FileVersion;
 use Kirby\Cms\Url;
 
 App::plugin('getkirby/cdn', [

--- a/site/plugins/cdn/src/FileVersion.php
+++ b/site/plugins/cdn/src/FileVersion.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Kirby\Cdn;
+
+use Kirby\Cms\FileVersion as BaseFileVersion;
+use Kirby\Image\Dimensions;
+
+/**
+ * Modified FileVersion class to provide the correct dimensions
+ * for a thumb generated in the CDN context
+ * where no actual thumb file can be measured
+ */
+class FileVersion extends BaseFileVersion
+{
+	protected Dimensions|null $dimensions = null;
+
+	public function dimensions(): Dimensions
+	{
+		if ($this->dimensions !== null) {
+			return $this->dimensions;
+		}
+
+		$dimensions = new Dimensions(
+			width: $this->original()->width(),
+			height: $this->original()->height(),
+		);
+
+		if (empty($this->modifications()) === false) {
+			$dimensions = $dimensions->thumb($this->modifications());
+		}
+
+		return $this->dimensions = $dimensions;
+	}
+
+	public function height(): int
+	{
+		return $this->dimensions()->height();
+	}
+
+	public function width(): int
+	{
+		return $this->dimensions()->width();
+	}
+}


### PR DESCRIPTION
## Description
### Summary of changes
- Add `FileVersion` variant for our `cdn` plugin that calculates width and hight dimensions from the passed modifications array

### Reasoning
In the CDN context, we cannot easily measure the dimensions of the thumb file. Which is why without this fix, `$thumb->width()` and `$thumb->height()` would return the dimensions of the original, not the thumb. This PR fixes that.