### PR TITLE
Fix broken link to $site->search()

### DIFF
--- a/content/docs/3_cookbook/0_collections/0_search/cookbook-recipe.txt
+++ b/content/docs/3_cookbook/0_collections/0_search/cookbook-recipe.txt
@@ -16,7 +16,7 @@ Tags: collections, search
 
 Text:
 
-(link: docs/reference/objects/site/search text: Search) is a built-in core feature. You can search all pages of your site or specific sets of pages. In this example you are going to learn how to build a simple search page, how to configure the search and how to display results.
+(link: docs/reference/objects/cms/site/search text: Search) is a built-in core feature. You can search all pages of your site or specific sets of pages. In this example you are going to learn how to build a simple search page, how to configure the search and how to display results.
 
 ## Setting up the search page
 


### PR DESCRIPTION
## Description
The link to the documentation page for the `$site->search()` method was broken—I'm guessing this is due to the recent website update (which I love, by the way)—so I found the correct link and updated it. :)

### Summary of changes
Fixed broken link.


### Reasoning
Working links make docs more useful.


### Additional context
I mean, this is pretty straightforward.


