### PR TITLE
Increase clickable area of menu links

### DIFF
--- a/assets/css/site/footer.css
+++ b/assets/css/site/footer.css
@@ -10,6 +10,7 @@
 
 .footer-menu a {
 	display: block;
+	padding: 0.1rem 0;
 }
 .footer-menu-partners a {
 	padding: 0.25rem 0;

--- a/assets/css/site/sidebar.css
+++ b/assets/css/site/sidebar.css
@@ -5,15 +5,19 @@
 	color: var(--color-black);
 }
 
-.sidebar li {
-	margin-bottom: 0.25rem;
-}
-
 .sidebar .details {
 	margin-left: -1.75rem;
 }
 .sidebar .details summary::after {
-	margin-top: 0.25rem;
+	margin-top: 0.4rem;
+}
+.sidebar .sidebar-group .details summary::after {
+	margin-top: 0.27rem;
+}
+
+.sidebar ul a {
+	display: block;
+	padding: 0.125rem 0;
 }
 
 .sidebar-menu-2 {
@@ -55,6 +59,7 @@
 
 .sidebar .sidebar-group .sidebar-menu-2 li > a {
 	font-size: var(--text-xs);
+	padding: 0.25rem 0;
 }
 .sidebar .sidebar-group .sidebar-menu-2 {
 	padding-top: 0.25rem;


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.
-->

### Summary of changes

- Footer menu links are now less dense / further apart vertically
- In the sidebar menus of the guide, reference and legal pages, the paddings have been moved to the `<a>` tags while keeping the overall spacings more or less the same
- The positions of the summary +/- buttons in the guide and reference have been adapted to the new spacing

### Reasoning

Increase clickable areas of links and thus improving accessibility and UX