### PR TITLE
Fix invalid markup in reference

### DIFF
--- a/site/snippets/templates/reference/section.php
+++ b/site/snippets/templates/reference/section.php
@@ -1,14 +1,12 @@
 <ul class="reference-section mb-12 auto-fill" style="--min: 15rem; --row-gap: 0; --column-gap: var(--spacing-3)">
 	<?php foreach ($item as $entry): ?>
 	<li>
-		<a href="<?= $entry->url() ?>" class="flex items-center">
+		<a href="<?= $entry->url() ?>" class="flex items-center mb-1">
 			<?php snippet(
 				'templates/reference/entry/decoration',
 				['entry' => $entry]
 			) ?>
-			<div class="">
-				<h3 class="mb-1"><?= $entry->title() ?></h3>
-			</div>
+			<?= $entry->title() ?>
 		</a>
 	</li>
 	<?php endforeach ?>


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.
-->

### Summary of changes

Convert nested heading inside a link to a plain link

### Reasoning

- Block-level markup in links is not allowed
- It is unclear why we have a `<h3>` there in the first place as it's not a heading but a link to another reference page
