### PR TITLE
fix docs for global events on custom dropdowns

### DIFF
--- a/content/docs/2_reference/7_plugins/1_extensions/0_panel-dropdowns/reference-extension.txt
+++ b/content/docs/2_reference/7_plugins/1_extensions/0_panel-dropdowns/reference-extension.txt
@@ -159,8 +159,7 @@ $dropdown[] = [
 	'icon'  => 'share',
 	'text'  => 'Publish on Netlify',
 	'click' => [
-		'key'     => 'myEvent'
-		'global'  => true,
+		'global'  => 'myEvent',
 		'payload' => [...]
 	]
 ];


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.
-->
This PR fixes the docs regarding the global events on custom dropdown menu items. 
The previous docs mention a `key` property for the event name. There is no such property however in the actual code. The event name is determined by the value of `global` instead. 

### Summary of changes
The code example:

```diff
$dropdown[] = [
    'icon'  => 'share',
    'text'  => 'Publish on Netlify',
    'click' => [
-       'key'     => 'myEvent'
-       'global'  => true,
+       'global'  => 'myEvent',
        'payload' => [...]
    ]
];
```

### Additional context

Forum thread mentioning this
https://forum.getkirby.com/t/error-in-documentation-for-panel-dropdowns/32195

The pull request implementing this
https://github.com/getkirby/kirby/pull/6411

The responsible piece of code
https://github.com/getkirby/kirby/blob/f9f00b16a22fe9dbbbddc2bfd4719ca3437cbee9/panel/src/components/Dropdowns/DropdownContent.vue#L209-L211


