### PR TITLE
fix docs: example code for files section parent option

### DIFF
--- a/content/docs/2_reference/3_panel/4_sections/0_files/reference-panelsection.txt
+++ b/content/docs/2_reference/3_panel/4_sections/0_files/reference-panelsection.txt
@@ -288,7 +288,7 @@ empty: No documents yet
 By default, the current page is being used as the parent to find files for the list. With this option, any page on your site can be the parent of the section.
 
 ```yaml
-parent: site.find("galleries").first
+parent: site.find("galleries")
 ```
 <since v="4.0.0">
 ### `query`


### PR DESCRIPTION
## Description
Fixes the [code example](https://getkirby.com/docs/reference/panel/sections/files#filtering-files__parent) for the `parent` option in the files section. 

### Summary of changes

```diff
-parent: site.find("galleries").first
+parent: site.find("galleries")
```

### Reasoning
`$site->find(...)`, when called with a single string argument, returns a single Page or null, calling `first()` on it suggests that it would return a Pages collection, but that isn't the case. 

### Additional context
https://getkirby.com/docs/reference/objects/cms/site/find


