### PR TITLE
fix docs: replace tabs with spaces in yaml code examples

### DIFF
--- a/content/docs/1_guide/7_blueprints/1_layout/guide.txt
+++ b/content/docs/1_guide/7_blueprints/1_layout/guide.txt
@@ -50,14 +50,14 @@ In this example we use multiple (link: docs/reference/panel/sections/files text:
 title: My blueprint
 
 sections: # keyword that allows you to add multiple section types
-	drafts:
-		type: pages
-		label: Drafts
-		status: draft
-	published:
-		type: pages
-		label: Published pages
-		status: listed
+  drafts:
+    type: pages
+    label: Drafts
+    status: draft
+  published:
+    type: pages
+    label: Published pages
+    status: listed
 ```
 
 

--- a/content/docs/1_guide/7_blueprints/6_translations/guide.txt
+++ b/content/docs/1_guide/7_blueprints/6_translations/guide.txt
@@ -18,8 +18,8 @@ The title can be translated by passing an array of translations with the matchin
 
 ```yaml
 title:
-	en: Example Page
-	de: Beispiel Seite
+  en: Example Page
+  de: Beispiel Seite
 ```
 
 ## Section labels

--- a/content/docs/2_reference/3_panel/1_blueprints/0_page/reference-article.txt
+++ b/content/docs/2_reference/3_panel/1_blueprints/0_page/reference-article.txt
@@ -40,8 +40,8 @@ The title can be translated by passing an array of translations with the matchin
 
 ```yaml
 title:
-	en: Article
-	de: Artikel
+  en: Article
+  de: Artikel
 ```
 
 ## Sorting
@@ -96,8 +96,8 @@ With the `status` option, you define the page statuses you want to allow for the
 
 ```yaml
 status:
-	draft: Draft
-	listed: Published
+  draft: Draft
+  listed: Published
 ```
 
 ### Extended example
@@ -256,8 +256,8 @@ Or when defining other options, set the `query` option to `false`:
 
 ```yaml
 image:
-	back: blue
-	query: false
+  back: blue
+  query: false
 ```
 
 To show no image or icon at all, you can set the `image` option to `false`:

--- a/content/docs/2_reference/3_panel/1_blueprints/0_site/reference-article.txt
+++ b/content/docs/2_reference/3_panel/1_blueprints/0_site/reference-article.txt
@@ -28,8 +28,8 @@ The title can be translated by passing an array of translations with the matchin
 
 ```yaml
 title:
-	en: Site
-	de: Webseite
+  en: Site
+  de: Webseite
 ```
 
 ## Options

--- a/content/docs/2_reference/3_panel/1_blueprints/0_user/reference-article.txt
+++ b/content/docs/2_reference/3_panel/1_blueprints/0_user/reference-article.txt
@@ -138,9 +138,9 @@ The `permissions` option can be used to restrict access to certain actions for t
 
 ```yaml
 permissions:
-	access:
-		settings: false
-		users: false
+  access:
+    settings: false
+    users: false
 ```
 
 
@@ -158,8 +158,8 @@ permissions:
 
 ```yaml
 permissions:
-	files:
-	  delete: false
+  files:
+    delete: false
 ```
 
 ### `pages`
@@ -183,10 +183,10 @@ permissions:
 
 ```yaml
 permissions:
-	pages:
-		delete: false
-		create: false
-		changeTemplate: false
+  pages:
+    delete: false
+    create: false
+    changeTemplate: false
 ```
 
 ### `site`
@@ -221,12 +221,12 @@ It is also possible to set the `users` options individually.
 
 ```yaml
 permissions:
-	access:
-		users: true
-	users:
-		delete: false
-		create: false
-		changeRole: false
+  access:
+    users: true
+  users:
+    delete: false
+    create: false
+    changeRole: false
 ```
 
 ### `user`
@@ -251,12 +251,12 @@ This user can access the user management, but not edit other users. The user can
 
 ```yaml
 permissions:
-	access:
-		users: true
-	users: false
-	user:
-		delete: false
-		changeRole: false
+  access:
+    users: true
+  users: false
+  user:
+    delete: false
+    changeRole: false
 ```
 
 ### Using wildcards
@@ -264,7 +264,7 @@ It's also possible to restrict access to entire blocks by just passing `false` t
 
 ```yaml
 permissions:
-	pages: false
+  pages: false
 ```
 
 ## Examples

--- a/content/docs/2_reference/3_panel/3_fields/0_structure/reference-article.txt
+++ b/content/docs/2_reference/3_panel/3_fields/0_structure/reference-article.txt
@@ -107,26 +107,26 @@ You can define the columns that are shown in the table. This is especially usefu
 
 ```yaml
 fields:
-	holidays:
-		type: structure
-		columns:
-			title:
-				width: 1/4
-			images:
-				width: 1/2
-			price:
-				width: 1/4
-				align: right
-				after: "USD"
-		fields:
-			title:
-				type: text
-			images:
-				type: files
-			description:
-				type: textarea
-			price:
-				type: number
+  holidays:
+    type: structure
+    columns:
+      title:
+        width: 1/4
+      images:
+        width: 1/2
+      price:
+        width: 1/4
+        align: right
+        after: "USD"
+    fields:
+      title:
+        type: text
+      images:
+        type: files
+      description:
+        type: textarea
+      price:
+        type: number
 ```
 
 Structure columns can be set to any fraction and will be automatically calculated into the right width.
@@ -159,23 +159,23 @@ You can also define columns without additional options if you want to use the de
 
 ```yaml
 fields:
-	holidays:
-		type: structure
-		columns:
-			title: true
-			images: true
-			price:
-				align: right
-				after: "USD"
-		fields:
-			title:
-				type: text
-			images:
-				type: files
-			description:
-				type: textarea
-			price:
-				type: number
+  holidays:
+    type: structure
+    columns:
+      title: true
+      images: true
+      price:
+        align: right
+        after: "USD"
+    fields:
+      title:
+        type: text
+      images:
+        type: files
+      description:
+        type: textarea
+      price:
+        type: number
 ```
 
 ### Hide toggle field text in preview

--- a/content/docs/2_reference/3_panel/3_fields/0_time/reference-article.txt
+++ b/content/docs/2_reference/3_panel/3_fields/0_time/reference-article.txt
@@ -49,7 +49,7 @@ display: h.m.s a
 | `mm` | 00-59 | Minute, 2-digits
 | `s` | 0-59 | Second
 | `ss` | 00-59 | Second, 2-digits
-| `A` | AM PM	| |
+| `A` | AM PM | |
 | `a` | am pm | |
 
 The field will parse any input by matching it to the display format. `display: HH:ss` will match an input of `09:35`. It will also match partials or slight variations, e.g. `09`, `9`. The base for partials will be the current time.

--- a/content/docs/2_reference/3_panel/4_sections/0_pages/reference-panelsection.txt
+++ b/content/docs/2_reference/3_panel/4_sections/0_pages/reference-panelsection.txt
@@ -259,11 +259,11 @@ Check out the [field previews in our Lab](https://lab.getkirby.com/public/lab/co
 layout: table
 info: "{{ page.slug }}"
 columns:
-	title:
-		label: Custom title label
-	info:
-		label: Custom slug label
-		width: 10rem
+  title:
+    label: Custom title label
+  info:
+    label: Custom slug label
+    width: 10rem
 ```
 </since>
 
@@ -297,7 +297,7 @@ image:
   query: page.cover.toFile
   icon: 📝
   back: blue-700
-	color: white
+  color: white
   cover: true
 ```
 
@@ -335,15 +335,15 @@ otherPosts:
   type: pages
   label: Other posts
   query: page.childrenAndDrafts.filterBy('category', '!=', 'video')
-	template: article
+  template: article
 ```
 The query option cannot only be used in the context of a single page, but you can also query the complete site index if that makes sense, for example in `site.yml`:
 
 ```yaml
 siteIndex:
-	type: pages
-	query: site.index(true).notIn(['error'])
-	create: default
+  type: pages
+  query: site.index(true).notIn(['error'])
+  create: default
 ```
 </since>
 ### Status

--- a/content/docs/2_reference/3_panel/8_samples/0_events/reference-article.txt
+++ b/content/docs/2_reference/3_panel/8_samples/0_events/reference-article.txt
@@ -25,17 +25,17 @@ sections:
   drafts:
     extends: sections/events
     label: Unpublished events
-		status: draft
+    status: draft
 
   unlisted:
     extends: sections/events
     label: Unlisted events
-		status: unlisted
+    status: unlisted
 
   listed:
     extends: sections/events
     label: Published events
-		status: listed
+    status: listed
 ```
 
 ### Predefined section for reusage


### PR DESCRIPTION
## Description
I've replaced ~~all tabs~~ the tabs I've found with spaces in yaml code examples. 

### Reasoning
Tabs are explicitly discouraged by the spec:
https://yaml.org/spec/1.2.2/#61-indentation-spaces

Also, there were multiple instances where tabs and spaces were mixed in examples, and since the tabs are displayed as four spaces in the docs, it looked like there were wrong indentations:
<img width="532" alt="image" src="https://github.com/user-attachments/assets/f7f8375d-99a9-473f-86ce-606080990af6">

