### PR TITLE
Events: fix timezone support

### DIFF
--- a/site/models/event.php
+++ b/site/models/event.php
@@ -7,16 +7,25 @@ class EventPage extends Page
 {
 	public function date(): Field
 	{
-		return parent::date()->value($this->num() . ' ' . $this->start()->or('18:00:00'));
+		return parent::date()->value(
+			$this->num() . ' ' . $this->start() . ' ' . $this->timezone()
+		);
+	}
+
+	public function datetime(): DateTime
+	{
+		return new DateTime(
+			(string)$this->date(),
+			new DateTimeZone((string)$this->timezone())
+		);
 	}
 
 	public function icon(): string
 	{
-		if ($this->isMeetup() === true) {
-			return '📍';
-		}
-
-		return '🗓️';
+		return parent::icon()->or(match (true) {
+			$this->isMeetup() => '📍',
+			default           => '🗓️'
+		});
 	}
 
 	public function isMeetup(): bool
@@ -50,6 +59,16 @@ class EventPage extends Page
 		}
 
 		return parent::shortTitle()->value(implode(' ', $title));
+	}
+
+	public function start(): Field
+	{
+		return parent::start()->or('18:00:00');
+	}
+
+	public function timezone(): Field
+	{
+		return parent::timezone()->or('Europe/Berlin');
 	}
 
 	public function title(): Field

--- a/site/snippets/templates/meet/event.php
+++ b/site/snippets/templates/meet/event.php
@@ -2,8 +2,17 @@
 	<h3><?= $event->icon() ?> <?= $event->shortTitle() ?></h3>
 
 	<?php if ($event->isUpcoming() === true): ?>
-	<localized-datetime date="<?= $event->date()->toDate('Y-m-d H:i:s') ?>"><?= $event->date()->toDate('D, j M Y, H:i T') ?></localized-datetime>
+		<localized-datetime
+			date="<?= $event->datetime()->format('c') ?>"
+			<?php if ($event->isMeetup()) : ?>
+			timezone="<?= $event->timezone() ?>"
+			<?php endif ?>
+		>
+			<?= $event->datetime()->format('D, j M Y, H:i T') ?>
+		</localized-datetime>
 	<?php else: ?>
-	<time date="<?= $event->date()->toDate('Y-m-d H:i:s') ?>"><?= $event->date()->toDate('D, j M Y') ?></time>
+	<time date="<?= $event->datetime()->format('c') ?>">
+		<?= $event->datetime()->format('D, j M Y') ?>
+	</time>
 	<?php endif ?>
 </a>

--- a/site/snippets/templates/meet/events.js.php
+++ b/site/snippets/templates/meet/events.js.php
@@ -2,11 +2,12 @@
 class LocalizedDatetimeElement extends HTMLElement {
 	connectedCallback() {
 		this.utc = new Date(this.getAttribute("date"));
-		this.innerText = this.format(this.utc);
+		this.timezone = this.getAttribute("timezone");
+		this.innerText = this.format(this.utc, this.timezone);
 	}
 
-	format(datetime) {
-		return datetime.toLocaleString("en-US", {
+	format(datetime, timezone) {
+		const options = {
 			weekday: "short",
 			day: "numeric",
 			month: "long",
@@ -15,7 +16,13 @@ class LocalizedDatetimeElement extends HTMLElement {
 			hour: "2-digit",
 			minute: "2-digit",
 			timeZoneName: "short"
-		})
+		};
+
+		if (timezone) {
+			options.timeZone = timezone;
+		}
+
+		return datetime.toLocaleString("en-US", options)
 	}
 }
 


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.
-->

### Summary of changes
After the last changes to events, the timezone support has been broken. It shows up the `start` time but with the timezone suffix of the user, which combined is wrong:

<img width="1300" alt="Screenshot 2024-10-10 at 9 56 04 PM" src="https://github.com/user-attachments/assets/4c6545ec-1b85-46bf-9783-84347bc5efe3">


- Adds support for `timezone` field which defaults to `Europe/Berlin`
- New `$event->datetime()` method that creates a DateTime object with timezone baked in
- Display datetimes
  - for meetup in the timezone of the place of the event
  - for all other events (likely all online) adapted to the user's timezone

<img width="1335" alt="Screenshot 2024-10-11 at 10 17 48 AM" src="https://github.com/user-attachments/assets/51cdba22-cc48-4a00-bb2f-59c620f5363d">

