### PR TITLE
Meet: expire cache at next event

### DIFF
--- a/site/config/cache.php
+++ b/site/config/cache.php
@@ -5,10 +5,6 @@ return [
 		'active' => true,
 		'type'   => 'file'
 	],
-	'meet' => [
-		'active' => true,
-		'type'   => 'file'
-	],
 	'pages' => [
 		'active' => true,
 		'type'   => 'file',
@@ -17,7 +13,6 @@ return [
 			'features-for-clients',
 			'home',
 			'love',
-			'meet',
 			'partners',
 			'scenario-education',
 			'themes',

--- a/site/config/config.getkirby.test.php
+++ b/site/config/config.getkirby.test.php
@@ -1,12 +1,6 @@
 <?php
 
 return [
-	'cache' => [
-		'meet' => [
-			'active' => true,
-			'type'   => 'file'
-		],
-	],
 	'debug' => true,
 	'email' => [
 		'transport' => [

--- a/site/config/routes.php
+++ b/site/config/routes.php
@@ -21,7 +21,6 @@ return [
 
 			if (empty($key) === false && get('key') === $key) {
 				kirby()->cache('diffs')->flush();
-				kirby()->cache('meet')->flush();
 				kirby()->cache('pages')->flush();
 				kirby()->cache('reference')->flush();
 			}

--- a/site/controllers/meet.php
+++ b/site/controllers/meet.php
@@ -1,9 +1,21 @@
 <?php
 
-return function () {
+use Kirby\Cms\App;
+
+return function (App $kirby) {
+	$events   = collection('events');
+	$upcoming = $events->filterBy('isUpcoming', true);
+
+	// expire the cache 2h after the next upcoming event starts
+	if ($next = $upcoming->first()) {
+		$time = $next->datetime()->getTimestamp() + (60 * 60 * 2);
+		$kirby->response()->expires($time);
+		$kirby->response()->header('Expires', gmdate('D, d M Y H:i:s T', $time));
+	}
+
 	return [
-		'events'   => $events = collection('events'),
-		'upcoming' => $events->filterBy('isUpcoming', true),
+		'events'   => $events,
+		'upcoming' => $upcoming,
 		'past'     => $events->filterBy('isUpcoming', false),
 		'gallery'  => $events->images()->shuffle(),
 	];

--- a/site/models/event.php
+++ b/site/models/event.php
@@ -35,7 +35,7 @@ class EventPage extends Page
 
 	public function isUpcoming(): bool
 	{
-		return $this->date()->toTimestamp() >= time();
+		return $this->datetime()->getTimestamp() >= time();
 	}
 
 	public function shortTitle(): Field


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.
-->

### Summary of changes
- Remove old `meet` cache that we don't use anymore
- Remove `meet` page from page cache ignore list
- Expire cache for `meet` page 2 hours after the next upcoming event starts


### Reasoning
As this page is growing, I think it'd be good to be cached when possible.

