### PR TITLE
Typo in description of cookbook-recipe.txt

### DIFF
--- a/content/docs/3_cookbook/0_headless/0_headless-kiosk-application/cookbook-recipe.txt
+++ b/content/docs/3_cookbook/0_headless/0_headless-kiosk-application/cookbook-recipe.txt
@@ -2,7 +2,7 @@ Title: Headless kiosk app
 
 ----
 
-Description: Use Kirby and 11ty to generate a headless kiosk application hat works offline.
+Description: Use Kirby and 11ty to generate a headless kiosk application that works offline.
 
 ----
 


### PR DESCRIPTION
## Description
There was a missing 't' in the description of this page. Should be 'that works offline' instead of 'hat works offline'. This PR just adds that 't' in.

### Summary of changes
Added missing 't' to description field.

Thank you.
