### PR TITLE
Added a hint that auth.challenge.email config is also used for pw-reset

### DIFF
--- a/content/docs/2_reference/6_system/1_options/0_auth/reference-article.txt
+++ b/content/docs/2_reference/6_system/1_options/0_auth/reference-article.txt
@@ -169,7 +169,7 @@ return [
 ```
 
 <info>
-If you want to customize the emails even more, take a look how to (link: docs/guide/authentication/login-methods#email-templates text: customize the email templates) in the guide.
+If you want to customize the emails even more, take a look how to (link: docs/guide/authentication/login-methods#email-templates text: customize the email templates) in the guide. Note also that this configuration is also used for the password-reset emails.
 </info>
 
 ### Challenge priority


### PR DESCRIPTION
## Description

It took me a moment to find the code creating the actual email for the password-reset and to realize that it also uses the email config from `auth.challenge.email` as the reset is also a challenge from that point of view. 

### Summary of changes

This commit drops a hopefully helpful note on that.

### Reasoning

From reading the docs I expected the `password-reset` functionality to use its own email configuration within the `auth` config or its own email preset, but could not find any information on that.

### Additional context

None.

