### PR TITLE
Update php quotes in collections guide.txt

### DIFF
--- a/content/docs/1_guide/6_templates/6_collections/guide.txt
+++ b/content/docs/1_guide/6_templates/6_collections/guide.txt
@@ -61,9 +61,9 @@ return function ($site) {
 Collections can be used in templates and snippets like this:
 
 ```php
-$kirby->collection("articles");
-$kirby->collection("admins");
-$kirby->collection("project-covers");
+$kirby->collection('articles');
+$kirby->collection('admins');
+$kirby->collection('project-covers');
 ```
 
 You can loop through the collections like through any collection like this:
@@ -94,7 +94,7 @@ return function ($site) {
 ```
 
 ```php
-$kirby->collection("articles/latest");
+$kirby->collection('articles/latest');
 ```
 
 ## Best practices


### PR DESCRIPTION
Use single quotes in PHP code consistently.

## Description
On the collections guide page single quotes are used for almost all code examples. But there has been a few exceptions.

### Summary of changes
Change all remaining double quotes to single quotes.

### Reasoning
Consistency :)

### Additional context
–


