### PR TITLE
FAQ block example: improve marks usage

### DIFF
--- a/content/docs/1_guide/8_page-builder/4_block-examples/guide.txt
+++ b/content/docs/1_guide/8_page-builder/4_block-examples/guide.txt
@@ -378,6 +378,12 @@ panel.plugin("cookbook/block-factory", {
         },
         headingField() {
           return this.field("heading");
+        },
+				faqQuestionField() {
+          return this.field('faq').fields.question;
+        },
+				faqAnswerField() {
+          return this.field('faq').fields.answer;
         }
       },
       methods: {
@@ -407,7 +413,7 @@ panel.plugin("cookbook/block-factory", {
                 <k-writer
                   ref="question"
                   :inline="true"
-                  :marks="false"
+                  :marks="faqQuestionField.marks"
                   :value="item.question"
                   @input="updateItem(content, index, 'question', $event)"
                 />
@@ -415,7 +421,7 @@ panel.plugin("cookbook/block-factory", {
               <k-writer
                 class="label"
                 ref="answer"
-                :marks="true"
+                :marks="faqAnswerField.marks"
                 :value="item.answer"
                 @input="updateItem(content, index, 'answer', $event)"
               />


### PR DESCRIPTION
Better in this case to reuse the marks from the structure field fields, so that when changing those (e.g. limiting to certain marks) this is also reflected in the preview.