### PR TITLE
Fix typo on CSS styling page

### DIFF
--- a/content/docs/2_reference/3_panel/7_styling/reference-article.txt
+++ b/content/docs/2_reference/3_panel/7_styling/reference-article.txt
@@ -55,7 +55,7 @@ Besides adding more CSS selectors, we are also using data attributes to allow fo
 
 ## CSS properties
 
-We use CSS properties for the most important parameters in the Panel. This is useful for customising the look of the Panel but als for plugin developers to create UIs that seamlessly integrate with the rest of the Panel.
+We use CSS properties for the most important parameters in the Panel. This is useful for customising the look of the Panel but also for plugin developers to create UIs that seamlessly integrate with the rest of the Panel.
 
 You can overwrite our default properties in your custom `panel.css`:
 


### PR DESCRIPTION
## Description
Fixed typo on the styling documentation page:
https://getkirby.com/docs/reference/panel/styling

### Summary of changes
Updated 'als' to 'also'.



