### PR TITLE
Fix typo in cookbook-recipe.txt

### DIFF
--- a/content/docs/3_cookbook/0_frontend/0_frontend-libraries/cookbook-recipe.txt
+++ b/content/docs/3_cookbook/0_frontend/0_frontend-libraries/cookbook-recipe.txt
@@ -97,7 +97,7 @@ Open the `site/snippets/footer.php` snippet. Right before the closing `/body` ta
 <?php endif ?>
 ```
 
-This will creat the following `script` tag when rendered:
+This will create the following `script` tag when rendered:
 
 ```html
 <script src="https://yourdomain/assets/js/Glider.js-master/glider.js"></script>


### PR DESCRIPTION
## Description

Fixes an obvious typo in the documentation.

### Summary of changes

"creat" → "create"
