### PR TITLE
fix typo in code example reference-article.txt

### DIFF
--- a/content/docs/2_reference/3_panel/3_fields/0_tel/reference-article.txt
+++ b/content/docs/2_reference/3_panel/3_fields/0_tel/reference-article.txt
@@ -38,7 +38,7 @@ Just printing the phone number:
 ```php
 <?php if ($page->phone()->isNotEmpty()): ?>
   <dt>Phone</dt>
-  <dd>$page->phone() ?></dd>
+  <dd><?= $page->phone() ?></dd>
 <?php endif ?>
 ```
 


### PR DESCRIPTION
## Description
There was a missing php echo shorthand in a code block example.

### Summary of changes
I added the opening php echo tag




