### PR TITLE
Update guide.txt

### DIFF
--- a/content/docs/1_guide/10_configuration/guide.txt
+++ b/content/docs/1_guide/10_configuration/guide.txt
@@ -173,7 +173,7 @@ return [
 ];
 ```
 
-You can read more in the (link: reference/system/options/url text: reference).
+You can read more in the (link: docs/reference/system/options/url text: reference).
 
 ## Multi-environment setup
 


### PR DESCRIPTION
Fixed link. `docs` was missing from docs/reference/system/options/url