### PR TITLE
[v5] fix: Improved support for DocBlock parameters

### DIFF
--- a/site/plugins/site/src/Reference/Reflectable/Tags/Parameter.php
+++ b/site/plugins/site/src/Reference/Reflectable/Tags/Parameter.php
@@ -78,7 +78,7 @@ class Parameter
 		$default = str_replace('array (' . PHP_EOL . ')', '[ ]', $default);
 
 		if ($default === null || $default === 'null') {
-			return null;
+			return 'null';
 		}
 
 		return $default;


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.
-->

### Summary of changes
- DocBlock parameters are now also considered if they describe additional parameters not picked up by the PHP reflection
- `$args` parameter is removed if any other parameter is documented
- `null` as default value for parameters is now displayed
