### PR TITLE
Meet events: support end time

### DIFF
--- a/content/meet/events/20250514_community-meetup-berlin-7/event.txt
+++ b/content/meet/events/20250514_community-meetup-berlin-7/event.txt
@@ -1,5 +1,7 @@
 start: 19:00:00
 ----
+end: 22:00:00
+----
 city: Berlin
 ----
 country: Germany

--- a/content/meet/events/20250621_community-meetup-gosport-1/event.txt
+++ b/content/meet/events/20250621_community-meetup-gosport-1/event.txt
@@ -1,5 +1,7 @@
 start: 18:00:00
 ----
+end: 23:00:00
+----
 city: Gosport
 ----
 timezone: Europe/London

--- a/site/models/event.php
+++ b/site/models/event.php
@@ -1,32 +1,37 @@
 <?php
 
-use Kirby\Cms\Page;
 use Kirby\Content\Field;
 use Kirby\Toolkit\Str;
 
-class EventPage extends Page
+class EventPage extends DefaultPage
 {
-	public function date(): Field
+	public function date(string $time = 'start'): Field
 	{
 		return parent::date()->value(
-			$this->num() . ' ' . $this->start() . ' ' . $this->timezone()
+			$this->num() . ' ' . $this->{$time}() . ' ' . $this->timezone()
 		);
 	}
 
-	public function datetime(): DateTime
-	{
+	public function datetime(
+		string|null $timezone = null,
+		string $time = 'start',
+	): DateTime {
 		return new DateTime(
-			(string)$this->date(),
-			new DateTimeZone((string)$this->timezone())
+			datetime: $this->date($time),
+			timezone: new DateTimeZone($timezone ?? $this->timezone())
 		);
 	}
 
-	/**
-	 * Returns the UTC datetime of the event
-	 */
-	function datetimeUtc(): DateTime
+	public function end(): Field
 	{
-		return $this->datetime()->setTimezone(new DateTimeZone('UTC'));
+		if (parent::end()->isNotEmpty()) {
+			return parent::end();
+		}
+
+		$start = $this->start();
+		$dt    = DateTime::createFromFormat('H:i:s', $start);
+		$dt->modify('+2 hours');
+		return parent::end()->value($dt->format('H:i:s'));
 	}
 
 	public function expiryTime(): int

--- a/site/models/event.php
+++ b/site/models/event.php
@@ -16,10 +16,16 @@ class EventPage extends DefaultPage
 		string|null $timezone = null,
 		string $time = 'start',
 	): DateTime {
-		return new DateTime(
+		$dt = new DateTime(
 			datetime: $this->date($time),
-			timezone: new DateTimeZone($timezone ?? $this->timezone())
+			timezone: new DateTimeZone($this->timezone())
 		);
+
+		if ($timezone !== null) {
+			$dt->setTimezone(new DateTimeZone($timezone));
+		}
+
+		return $dt;
 	}
 
 	public function end(): Field

--- a/site/snippets/templates/meet/calendar.php
+++ b/site/snippets/templates/meet/calendar.php
@@ -2,10 +2,11 @@
 BEGIN:VEVENT
 UID:meetup-<?= $event->slug() . "\r\n" ?>
 SUMMARY:<?= $event->foldTitle() . "\r\n" ?>
-DTSTART:<?= $event->datetimeUtc()->format('Ymd\THis\Z') . "\r\n" ?>
+DTSTART:<?= $event->datetime('UTC')->format('Ymd\THis\Z') . "\r\n" ?>
+DTEND:<?= $event->datetime('UTC', 'end')->format('Ymd\THis\Z') . "\r\n" ?>
 DTSTAMP:<?= $event->modified('Ymd\THis\Z') . "\r\n" ?>
 <?php if ($event->city()->isNotEmpty()): ?>
-LOCATION:<?= $event->city() ?>,<?= $event->country() . "\r\n" ?>
+LOCATION:<?= $event->city() ?>, <?= $event->country() . "\r\n" ?>
 <?php endif ?>
 <?php if ($event->link()->isNotEmpty()): ?>
 URL:<?= $event->foldLink() . "\r\n" ?>


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.
-->

### Summary of changes
- Support for `end` time field
- If `end` field is empty, fall back to +2 hours from start time for event duration
- Removed `EventPage:: datetimeUtc()` in favor of `::datetime(timezone: 'UTC')`
- Fixed ical location field: space after comma


### Reasoning
Currently calendars interpret the entries as 30 minutes long.

