### PR TITLE
Redesign revenue limit checkbox for more clarity

### DIFF
--- a/site/snippets/faq.php
+++ b/site/snippets/faq.php
@@ -1,10 +1,28 @@
 <div class="faq">
 	<?php foreach ($questions as $question): ?>
-	<details class="details">
-		<summary class="py-3 border-top" id="<?= $question->slug() ?>"><?= $question->title()->kti()->widont() ?></summary>
+	<details class="details" id="<?= $question->slug() ?>">
+		<summary class="py-3 border-top"><?= $question->title()->kti()->widont() ?></summary>
 		<div class="py-3 prose text-base">
 			<?= $question->text()->kt() ?>
 		</div>
 	</details>
 	<?php endforeach ?>
 </div>
+
+<script>
+function openFaqById(hash) {
+	const element = document.querySelector(hash);
+
+	if (element instanceof HTMLDetailsElement) {
+		element.open = true;
+	}
+}
+
+// open the FAQ entry onload
+if (window.location.hash) {
+	openFaqById(window.location.hash);
+}
+
+// open the FAQ entry when the hash in the URL changes (e.g. by clicking a relevant link)
+window.addEventListener('hashchange', () => openFaqById(window.location.hash));
+</script>

--- a/site/snippets/templates/buy/checkout.php
+++ b/site/snippets/templates/buy/checkout.php
@@ -286,7 +286,7 @@
 
 					<div v-if="product === '<?= $basic->value() ?>'" class="field">
 						<p class="font-bold">Confirm the revenue limit</p>
-						<p class="info mb-1">
+						<p class="info mb-3">
 							<mark>End customers must not exceed a total annual revenue/funding of
 							<strong><?= $revenueLimit ?><span v-if="locale.revenueLimit.length" v-text="locale.revenueLimit"></span></strong></mark>
 							to be eligible for the Kirby Basic license. <a class="underline" href="#revenue-limit">Read more…</a>

--- a/site/snippets/templates/buy/checkout.php
+++ b/site/snippets/templates/buy/checkout.php
@@ -48,10 +48,12 @@
 	justify-content: space-between;
 	background: rgba(255,255,255, .25);
 }
-.checkout .help {
-	font-size: var(--text-xs);
+.checkout :where(.info, .help) {
 	padding-top: var(--spacing-1);
 	color: var(--color-gray-700);
+}
+.checkout .help {
+	font-size: var(--text-xs);
 }
 .checkout .buttons {
 	margin-top: var(--spacing-8);
@@ -283,16 +285,19 @@
 					</div>
 
 					<div v-if="product === '<?= $basic->value() ?>'" class="field">
-						<label class="font-bold flex items-center" style="gap: var(--spacing-2)">
-							<input id="limit" type="checkbox" name="limit" required>
-							<span>Confirm the revenue limit <abbr title="Required" aria-hidden>*</abbr></span>
-						</label>
-						<p class="help">
+						<p class="font-bold">Confirm the revenue limit</p>
+						<p class="info mb-1">
 							<mark>End customers must not exceed a total annual revenue/funding of
 							<strong><?= $revenueLimit ?><span v-if="locale.revenueLimit.length" v-text="locale.revenueLimit"></span></strong></mark>
-							to be eligible for this license.
-							<button type="button" class="underline" @click="product = '<?= $enterprise->value() ?>'">Switch to Enterprise</button> to remove the revenue limit.
+							to be eligible for the Kirby Basic license. <a class="underline" href="#revenue-limit">Read more…</a>
 						</p>
+						<label class="flex items-baseline" style="gap: var(--spacing-2)">
+							<input id="limit" type="checkbox" name="limit" required>
+							<span>
+								I have read and understood this restriction <abbr title="Required" aria-hidden>*</abbr><br>
+								<button type="button" class="underline" @click="product = '<?= $enterprise->value() ?>'">Switch to Enterprise</button> to remove the revenue limit.
+							</span>
+						</label>
 					</div>
 				</div>
 				<div class="buttons">

--- a/site/snippets/templates/buy/product.php
+++ b/site/snippets/templates/buy/product.php
@@ -30,7 +30,7 @@
 					If the website is for a client, the limit applies to the client's total revenue/funding.
 				</p>
 				<p style="color: var(--color-gray-400)">
-					See the frequently asked questions below for more information.
+					See the <a class="underline" href="#revenue-limit">frequently asked questions below</a> for more information.
 				</p>
 			</div>
 		</details>


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.
-->

### Summary of changes

- FAQ entries now auto-open when they are being linked to
- The revenue limit info box on the buy page and the help text in the checkout now link to the relevant FAQ entry directly
- Redesigned revenue limit checkout:

**Before:**

<img width="623" alt="Revenue limit checkbox before the change" src="https://github.com/user-attachments/assets/bb140af2-9e57-44bb-a587-d564d22b51af" />

**After:**

<img width="623" alt="Revenue limit checkbox after the change" src="https://github.com/user-attachments/assets/320423b3-c608-4e3d-85b9-4a66864f9e59" />

### Reasoning

- Added clarity
- Makes the revenue limit less likely to be missed