### PR TITLE
Add meet.rss.php template

### DIFF
--- a/site/templates/meet.rss.php
+++ b/site/templates/meet.rss.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * @var \Kirby\Cms\Pages $upcoming
+ */
+
+header('Content-Type: application/rss+xml; charset=UTF-8');
+
+?><?xml version="1.0" encoding="utf-8"?><rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:wfw="http://wellformedweb.org/CommentAPI/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:atom="http://www.w3.org/2005/Atom">
+	<channel>
+		<title>Kirby meetup calendar</title>
+		<link>https://getkirby.com/meet</link>
+		<description>Connect with other Kirby developers around the world or meet face-to-face at a local meetup.</description>
+		<?php foreach ($upcoming as $event): ?>
+			<?php if (empty(get('city')) || strtolower(get('city')) == strtolower($event->city())): ?>
+				<item>
+					<title><?= $event->datetime()->format('Y-m-d') ?>: <?= $event->shortTitle()->value() ?></title>
+					<?php if ($event->link()->isNotEmpty()): ?>
+						<link><?= $event->link()->value() ?></link>
+					<?php endif ?>
+					<guid>https://getkirby.com/meet#meetup-<?= $event->slug() ?></guid>
+					<description><![CDATA[
+						<p><?= $event->datetime()->format('Y-m-d H:i') ?> (time zone <?= $event->timezone()->value() ?>)</p>
+						<?php if ($event->city()->isNotEmpty()): ?>
+							<p><?= $event->city() ?>, <?= $event->country() ?></p>
+						<?php endif ?>
+						<?php if ($event->link()->isNotEmpty()): ?>
+							<p><a href="<?= $event->link()->value() ?>"><?= $event->link()->value() ?></a></p>
+						<?php endif ?>
+					]]></description>
+				</item>
+			<?php endif ?>
+		<?php endforeach ?>
+	</channel>
+</rss>


### PR DESCRIPTION
## Description
At last night's Berlin meetup, my corner of the room chatted about the discoverability challenge for new meetup dates. The ICAL option does not necessarily suit everybody (and we weren't sure would our calendars even alert us about new additions). It would be very neat to have new meetups announced in my feed reader.

### Summary of changes
This adds an RSS content representation of the `/meet` page, listing all upcoming events in the most minimal valid RSS format ([ref.](https://www.rssboard.org/rss-specification)).

In addition, it is possible to filter the feed by city: `https://getkirby.com/meet.rss?city=berlin`

### Reasoning
As the data is already available in a structured format, this use of Kirby's content representations feature opens an additional path to consume the calendar data. Also: :orange_heart: RSS!

### Additional context
I don't have a working dev environment for getkirby.com, so while I validated the RSS markup in a mockup, the implementation is untested. I'd hope it is at least 99% production-ready and could serve as a base for a final production version. Sorry for not being able to test this myself!