### PR TITLE
Update release-guide.txt

### DIFF
--- a/content/releases/5/3_entries-field/release-guide.txt
+++ b/content/releases/5/3_entries-field/release-guide.txt
@@ -6,14 +6,14 @@ Subtitle: When one just isn't enough
 
 ----
 
-Teaser: The Entries field allows you to create and manage multiple entries for the same field. It is a powerful tool for creating and managing content in a structured way.
+Teaser: The Entries field allows you to create and manage multiple entries for the same field. It is a powerful tool for creating and managing content in a structured way. Let's call ours `myEntries`:
 
 ----
 
 Example:
 
 ```yaml
-entries:
+myEntries:
   type: entries
   min: 2
   max: 4
@@ -41,7 +41,7 @@ The entries field allows you to create and manage multiple entries for the same 
 It supports the `color`, `date`, `email`, `number`, `select`, `slug`, `tel`, `text`, `time`, `url` field types.
 
 ```yaml
-entries:
+myEntries:
   type: entries
   min: 2
   max: 4


### PR DESCRIPTION


## Description
The template example uses a field called `myEntries` but the previous examples have it called `entries`.
Change the previous two examples to make it more clear?

### Summary of changes

One text change to setup the example, two changed sample field names to match the following usage in a template.

### Reasoning

Confusion when the template example references an object that didn’t exist in the sample code

### Additional context

Just helps with clarity, in my eyes.

