### PR TITLE
Update reference-panelsection.txt

### DIFF
--- a/content/docs/2_reference/3_panel/4_sections/0_pages/reference-panelsection.txt
+++ b/content/docs/2_reference/3_panel/4_sections/0_pages/reference-panelsection.txt
@@ -219,7 +219,7 @@ columns:
   date:
     label: Date
     value: "on {{ page.date.toDate('d.m.Y') }}"
-		type: text
+    type: text
 ```
 
 If the page actually has a `date` field of type `date`, Kirby will automatically use the date field preview component for this column. However, this will clash with your custom value. This is why we also set `type: text`.


### PR DESCRIPTION
Corrected indentation on line 222.

## Description
On line 222 tab was used instead of space for indentation. This makes the text in the documentation appear like this:

    label: Date
    value: "on {{ page.date.toDate('d.m.Y') }}"
        type: text

### Summary of changes
Change from two tabs to spaces. Copied the spaces from the line above. 



### Reasoning
Makes the documentation better with the correct indentation. 


### Additional context
This is my first pull request, I'm sorry if I have done something wrong. I just want to help :-) 


