### PR TITLE
Adding "how to translate" error messages

### DIFF
--- a/content/docs/2_reference/2_templates/0_helpers/0_invalid/reference-helper.txt
+++ b/content/docs/2_reference/2_templates/0_helpers/0_invalid/reference-helper.txt
@@ -56,4 +56,14 @@ $messages = [
 ];
 ```
 
+If your site is set up to support multiple languages, you use (link: https://getkirby.com/docs/guide/languages/custom-language-variables text: custom language variables) to translate the messages. Reference your translations using the (link: https://getkirby.com/docs/reference/templates/helpers/t text: `t()`-method.) We recommend you set a fallback when using `t()`.
+
+```php
+$messages = [
+    'fname' => t('fname', 'Please enter a valid first name'),
+    'lname' => t('lname', 'Please enter a valid last name'),
+    'email' => t('email', 'Please enter a valid email address')
+];
+```
+
 You can find an example of `invalid()` used to create pages from frontend in (link: https://getkirby.com/docs/cookbook/forms/creating-pages-from-frontend text: this recipe).


### PR DESCRIPTION
Added (L59 … L67) explaining how to translate the messages returned by invalid() for multi-language sites.

## Description
The explanation omitted information on how to translate the messages piped through ?invalid(). After some research, I found [this forum post](https://forum.getkirby.com/t/how-to-translate-webform-messages/13870/2) and added the info.

### Summary of changes
Added short explainer and example at the end of the article.

### Reasoning
Kirby CMS is c capable of translation. It should be common practice to add information on how to translate to the cookbook articles to promote this capability and make the info easier to find.

### Additional context
—