### PR TITLE
Update cookbook-recipe.txt

### DIFF
--- a/content/docs/3_cookbook/0_development-deployment/0_shared-controllers/cookbook-recipe.txt
+++ b/content/docs/3_cookbook/0_development-deployment/0_shared-controllers/cookbook-recipe.txt
@@ -147,7 +147,7 @@ $post = $kirby->controller('post' , compact('page', 'pages', 'site', 'kirby'));
 ```
 
 <info>
-More info on the `controller()` method (link: docs/reference/objects/kirby/controller text: can be found in the docs).
+More info on the `controller()` method (link: docs/reference/objects/cms/app/controller text: can be found in the docs).
 </info>
 
 Then we'll gather our custom data that we need specifically just for the `post-video` template:


### PR DESCRIPTION
Fixes broken link

## Description
Link in cookbook leads to error page.  

### Summary of changes
Added the url to what I believe is the intended page. 

https://getkirby.com/docs/reference/objects/cms/app/controller


### Reasoning



### Additional context
I'm sorry if you intended to link to a page different from the one I changed it to. 

