### PR TITLE
Add warning to SmartyPants docs

### DIFF
--- a/content/docs/2_reference/6_system/1_options/0_smartypants/reference-article.txt
+++ b/content/docs/2_reference/6_system/1_options/0_smartypants/reference-article.txt
@@ -16,6 +16,10 @@ return [
 ];
 ```
 
+<warning>
+Warning: There's currently an (link: https://github.com/getkirby/kirby/issues/6344 text: unresolved issue) with the SmartyPants library. Using quotes in KirbyTag attributes can break HTML output.
+</warning>
+
 ## Custom replacements
 
 You can also override each of the default replacements:


### PR DESCRIPTION
## Description

As mentioned in https://github.com/getkirby/kirby/issues/6344, I've added a warning to the SmartPants docs about broken HTML output.

### Summary of changes

Added a `<warning>` element to the page.

### Reasoning

Users should not use SmartyPants when quotes can lead to broken HTML output.