### PR TITLE
fix file paths in v5-more-details page

### DIFF
--- a/content/releases/5/51_more-details/release-guide.txt
+++ b/content/releases/5/51_more-details/release-guide.txt
@@ -59,7 +59,7 @@ Text:
 
 The `site` controller data will now always be merged as default data with data from page template specific controllers. https://feedback.getkirby.com/422
 
-```php "site/controller/site.php"
+```php "site/controllers/site.php"
 return function () {
 	return [
 		'brand' => 'Kirby'
@@ -67,7 +67,7 @@ return function () {
 };
 ```
 
-```php "site/controller/campaign.php"
+```php "site/controllers/campaign.php"
 return function () {
 	return [
 		'testimonial' => 'Max'
@@ -75,7 +75,7 @@ return function () {
 };
 ```
 
-```php "site/template/campaign.php"
+```php "site/templates/campaign.php"
 Both are available:
 
 <?= $brand ?>: <?= $testimonial ?>
@@ -83,7 +83,7 @@ Both are available:
 
 You can also set a site controller for all content representations of a certain type:
 
-```php "site/controller/site.rss.php"
+```php "site/controllers/site.rss.php"
 return function () {
 	return [
 		'generator' => 'Kirby RSS Feed Generator'


### PR DESCRIPTION
## Description

Noticed these wrong paths while looking through the Kirby 5 docs.

### Summary of changes

Fixed file paths:

- `controller` => `controllers`
- `template` => `templates`



