### PR TITLE
Update cookbook-recipe.txt regarding HTML/listitems

### DIFF
--- a/content/docs/3_cookbook/0_security/0_access-restriction/cookbook-recipe.txt
+++ b/content/docs/3_cookbook/0_security/0_access-restriction/cookbook-recipe.txt
@@ -208,14 +208,16 @@ As soon as the user logged in, we display a logout link in the menu or somewhere
 
 ```php "/site/snippets/header.php"
 <nav id="menu" class="menu">
+	<ul>
   <?php foreach ($site->children()->listed() as $item): ?>
-    <?= $item->title()->link() ?>
+    <li><?= $item->title()->link() ?></li>
   <?php endforeach ?>
   <?php if ($user = $kirby->user()): ?>
     <li>
       <a href="<?= url('logout') ?>">Logout</a>
     </li>
   <?php endif ?>
+  </ul>
 </nav>
 ```
 


### PR DESCRIPTION
## Description
I fixed the code example for the linking to children and logout part, regarding proper list HTML.

### Summary of changes
Added `<ul>`, `<li>` where needed.


### Reasoning
HTML: Code example showed `<li>`s as direct children of `<nav>`, which is against the spec.


