### PR TITLE
Fix wrong centering on mobile of "Made in Europe" footer

### DIFF
--- a/site/snippets/layouts/footer.php
+++ b/site/snippets/layouts/footer.php
@@ -42,7 +42,7 @@
 						</li>
 					</ul>
 				</nav>
-				<p class="mb-3 color-gray-700 flex items-center">
+				<p class="mb-3 color-gray-700 flex">
 					🇪🇺 Made in Europe
 				</p>
 			</div>


### PR DESCRIPTION
This seems unnecessary on desktop also as far as I can tell, but more importantly causes unwanted horisontal centering (at least seems unwanted in my eyes) with the changing to flex column on @media screen and (max-width: 50rem)

Better just removed, and left aligned all the way?

![eddie-11-10-2025-13 56 14](https://github.com/user-attachments/assets/db0f1c21-4a54-48e7-8b03-8ec744b1de73)
