### PR TITLE
Kirby meets Tailwind CSS Cookbook: fixes "@source"-call to actually exclude the vendor-dir

### DIFF
--- a/content/docs/3_cookbook/0_frontend/0_kirby-meets-tailwindcss/cookbook-recipe.txt
+++ b/content/docs/3_cookbook/0_frontend/0_kirby-meets-tailwindcss/cookbook-recipe.txt
@@ -102,7 +102,7 @@ The above `tailwind.css` file is everything that is needed to run Tailwind CSS, 
 @import "tailwindcss";
 
 /* Exclude the 'vendor' directory from beeing scanned */
-@source "../vendor";
+@source not "../vendor";
 
 /* Adjusting variables and adding custom styles */
 @theme {


### PR DESCRIPTION
## Description
This fixes a wrong tailwindcss configuration in the example file. According to the [documentation](https://tailwindcss.com/docs/detecting-classes-in-source-files#ignoring-specific-paths) `@source` includes the following directory. The comment above hints an exclusion of the `vendor` directory. 

In a broader sense the given example configuration should explicitly `@source` the two main template directories or set a correct base path. In the given state the tailwindcss processor would not source the two main Kirby template directories. This could be done by explicitly sourcing the directories:

```
@source "../site/snippets";
@source "../site/templates";
```

or provide a [proper base path](https://tailwindcss.com/docs/detecting-classes-in-source-files#setting-your-base-path):

```
@import "tailwindcss" source("../");
```