### PR TITLE
docs: panel-area link target

### DIFF
--- a/content/docs/2_reference/7_plugins/1_extensions/0_panel-areas/reference-extension.txt
+++ b/content/docs/2_reference/7_plugins/1_extensions/0_panel-areas/reference-extension.txt
@@ -48,8 +48,11 @@ Kirby::plugin('yourname/todos', [
         // show / hide from the menu
         'menu' => true,
 
-        // link to the main area view
+        // link to the main area view (can also be an absolute URL)
         'link' => 'todos',
+
+        // optional; to open the link in a new tab
+        'target' => '_blank',
 
         // views
         'views' => [


### PR DESCRIPTION
## Description

Add the `target` option and clarify that absolute URLs are possible (e.g. for external links to analytics, etc.)

### Summary of changes

n/a

### Reasoning

I wanted to add an external link in the left sidebar menu and the docs do not currently mention this option.

### Additional context

n/a


