### PR TITLE
Update cookbook-recipe.txt with Git repo info

### DIFF
--- a/content/docs/3_cookbook/0_frontend/0_kirby-meets-tailwindcss/cookbook-recipe.txt
+++ b/content/docs/3_cookbook/0_frontend/0_kirby-meets-tailwindcss/cookbook-recipe.txt
@@ -122,6 +122,7 @@ npm install tailwindcss @tailwindcss/cli
 ```
 By executing the command above a `node_modules` folder with the required dependencies and the file `package-lock.json` will be automatically created in the project root.
 
+<info>Tailwind CLI expects <b>a git repository initialized</b> in the project root in order to collect classes from source files.</info>
 
 ## Build
 Now we have a fully functional basic setup and are ready to generate our CSS file. Make sure you are in the project root folder and start the `watch` or the `build` script as follows:


### PR DESCRIPTION
I feel like this info is required, because many people don't use git for their kirby projects (me being one of them 😜). If you don't have a git repository initialized, Tailwind won't find any source files to collect classes from. It would be nice if we would tell this info to people following this guide.