### PR TITLE
Fix typo in example for toFiles() method

### DIFF
--- a/content/docs/2_reference/2_templates/0_field-methods/0_to-files/reference-fieldmethod.txt
+++ b/content/docs/2_reference/2_templates/0_field-methods/0_to-files/reference-fieldmethod.txt
@@ -3,5 +3,5 @@ Examples:
 ```php
 <?php foreach ($page->gallery()->toFiles() as $image): ?>
   <img src="<?= $image->url() ?>" alt="<?= $image->alt() ?>">
-<?php endif ?>
+<?php endforeach ?>
 ```


### PR DESCRIPTION
## Description

A straightforward fix to a typo in the sample code for `$field->toFiles()`.