### PR TITLE
Update t function parameters to accept null values and array at $fall…

### DIFF
--- a/kirby/config/helpers.php
+++ b/kirby/config/helpers.php
@@ -550,9 +550,9 @@ if (Helpers::hasOverride('t') === false) { // @codeCoverageIgnore
 	 * Returns translate string for key from translation file
 	 */
 	function t(
-		string|array $key,
-		string|null $fallback = null,
-		string|null $locale = null
+		array|string $key = null,
+        array|string $fallback = null,
+        string $locale = null
 	): string|array|Closure|null {
 		return I18n::translate($key, $fallback, $locale);
 	}


### PR DESCRIPTION
## Description
This pull request makes a small update to the `t` helper function in `kirby/config/helpers.php`, adjusting its parameter types and default values for improved flexibility and type safety.

### Summary of changes
- The `$key` and `$fallback` parameters of the `t` function now accept both `array` and `string` types, and default to `null` if not provided.…back

### Reasoning
Since I18n::translate supports arrays in the $fallback variable, the helper should also support arrays. Otherwise the application throws an error.



