### PR TITLE
docs: add hint at 'method' option in API routes

### DIFF
--- a/content/docs/2_reference/7_plugins/1_extensions/0_api/reference-extension.txt
+++ b/content/docs/2_reference/7_plugins/1_extensions/0_api/reference-extension.txt
@@ -22,6 +22,7 @@ Kirby::plugin('my/api', [
     'routes' => [
       [
         'pattern' => 'my-endpoint',
+        'method' => 'GET', // optional, defaults to 'GET'
         'action'  => function () {
           return [
             'hello' => 'world'


### PR DESCRIPTION
## Description

I recently tried to add a custom endpoint for a plugin expecting to receive POST requests. Without the `method` option set to 'POST', Kirby's router will only return 404. It looks like this option is undocumented, so I'm at least adding a little hint in the code example.

### Summary of changes

Added optional `method` option to code sample in docs on custom api endpoints.