### PR TITLE
code template correction : aria-current value on breadcrumb

### DIFF
--- a/content/docs/3_cookbook/0_navigation/0_menus/cookbook-recipe.txt
+++ b/content/docs/3_cookbook/0_navigation/0_menus/cookbook-recipe.txt
@@ -224,7 +224,7 @@ if ($items->isNotEmpty()):
 <nav aria-label="breadcrumb">
   <ol>
     <?php foreach($site->breadcrumb() as $crumb): ?>
-    <li<?php e($crumb->isActive(), ' aria-current="location"') ?>><a href="<?= $crumb->url() ?>"><?= $crumb->title()->html() ?></a></li>
+    <li<?php e($crumb->isActive(), ' aria-current="page"') ?>><a href="<?= $crumb->url() ?>"><?= $crumb->title()->html() ?></a></li>
     <?php endforeach; ?>
   </ol>
 </nav>


### PR DESCRIPTION
For the current page, the aria-current must be "page" and not "location"

Ref : https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-current#values