### PR TITLE
Image performance improvements

### DIFF
--- a/site/plugins/site/extensions/tags.php
+++ b/site/plugins/site/extensions/tags.php
@@ -300,7 +300,8 @@ $tags['screencast'] = [
 			'url'    => $tag->value,
 			'poster' => $tag->poster ? $tag->file($tag->poster) : $tag->file('youtube.jpg'),
 			'title'  => $tag->title ?? null,
-			'text'   => $tag->text ?? null
+			'text'   => $tag->text ?? null,
+			'lazy'   => $tag->data['field']->key() !== 'screencast'
 		], true);
 	}
 ];

--- a/site/snippets/kirbytext/image.php
+++ b/site/snippets/kirbytext/image.php
@@ -14,10 +14,17 @@ echo Html::figure(
 			$link ?? $file->url(),
 			[
 				img($file, [
+					'src'   => [
+						'width' => 924
+					],
 					'alt'   => $alt ?? $file->alt()->or($caption),
 					'class' => 'rounded',
-					'src'   => [
-						'width' => 960
+					'srcset' => [
+						462,
+						690,
+						924,
+						1380,
+						1848,
 					],
 				])
 			],

--- a/site/snippets/kirbytext/screencast.php
+++ b/site/snippets/kirbytext/screencast.php
@@ -8,7 +8,7 @@
 	</header>
 	<figure class="video">
 		<?= video($url, $poster, [], [
-			'loading' => 'lazy'
+			'loading' => $lazy ? 'lazy' : null
 		]) ?>
 	</figure>
 </article>

--- a/site/snippets/templates/buzz/entry.php
+++ b/site/snippets/templates/buzz/entry.php
@@ -3,7 +3,7 @@
 		<article>
 			<figure class="rounded overflow-hidden mb-6 shadow-lg" style="--aspect-ratio: 800/400">
 				<?= video($entry->video(), $entry->image('youtube.jpg'), [], [
-					'loading' => 'lazy'
+					'loading' => $lazy ? 'lazy' : null
 				]) ?>
 			</figure>
 

--- a/site/snippets/video.php
+++ b/site/snippets/video.php
@@ -4,7 +4,7 @@
 			'src' => [
 				'width' => 616
 			],
-			'lazy' => $attr['lazy'] ?? false,
+			'lazy' => ($attr['loading'] ?? null) === 'lazy',
 			// sizes generated with https://ausi.github.io/respimagelint/
 			'sizes' => '(min-width: 1520px) 616px, (min-width: 1160px) 42.06vw, (min-width: 960px) calc(50vw - 56px), (min-width: 780px) calc(75vw - 84px), (min-width: 480px) calc(100vw - 96px), 90vw',
 			'srcset' => [

--- a/site/templates/buzz-entry.php
+++ b/site/templates/buzz-entry.php
@@ -23,9 +23,7 @@
 
 <?php if ($page->video()->isNotEmpty()): ?>
 	<figure class="rounded overflow-hidden mb-12 shadow-lg" style="--aspect-ratio: 800/400">
-		<?= video($page->video(), $page->image('youtube.jpg'), [], [
-			'loading' => 'lazy'
-		]) ?>
+		<?= video($page->video(), $page->image('youtube.jpg')) ?>
 	</figure>
 <?php endif ?>
 


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.
-->

### Summary of changes

- Only use lazy-loading for below-the-fold images
- `srcset` for full width KirbyText images

### Reasoning

- Increase loading performance
- Improve match of image sizes to screen (e.g. small screens, Retina desktop screens)