### PR TITLE
Update virtual pages guides

### DIFF
--- a/content/docs/1_guide/19_virtual-content/3_content-from-database/guide.txt
+++ b/content/docs/1_guide/19_virtual-content/3_content-from-database/guide.txt
@@ -2,41 +2,52 @@ Title: Content from a database
 
 ----
 
-Description: Create pages from a database and edit, add or delete entries in the Panel
+Description: Load data from database and show it as pages
 
 ----
 
-Intro: Create pages from a database and edit, add or delete entries in the Panel
+Intro: Load data from database and show it as pages
 
 ----
 
 Text:
 
 
-Content can also come from a database. This is particularly useful if you already have a large set of data stored in a MySQL or other relational database, like a huge database of products or articles. In only a few steps you can transform data from those databases into Kirby pages that behave like any Kirby page in the frontend, i.e. you can use Kirby's API to access, filter or search content, and edit it in the Panel together with all your file based content.
+Content can also come from a database. This is particularly useful if you already have a large set of data stored in a MySQL or other relational database, like a database of products or articles. You can transform data from such databases into Kirby pages that behave like any Kirby page in the frontend, i.e. you can use Kirby’s API to access, filter, or search the content.
 
+This guide covers the basic steps, such as establishing a connection to the database, accessing one or more tables, and converting database entries into children of a parent page in read-only mode. In this setup, the pages are generated dynamically from the database and cannot be modified through the Panel or written to the file system.
 
-This guide is a short intro into how to create pages from entries in a database table. It is intended as an outline, not a final solution. With lots of entries it would also become necessary to work on a custom collection for the result set that would only fetch the rows it really needs, but this would be more complex.
+To add advanced functionality (editing, adding, deleting pages, etc.), please refer to our (link: text: work-in-progress plugin).
 
-The example assumes a database table called comments with the following scheme:
+Our example assumes a database table called `comments` with the following schema:
 
-| Column | Datatype      | Primary Key | Unique
-| ----   | ----          | ----        | ----
-|`id`    | int           | yes         | yes
-|`text`  | VARCHAR (600) | no          | no
-|`user`  | VARCHAR (100) | no          | no
-|`slug`  | VARCHAR (185) | no          | yes
+| Column | Datatype           | Primary Key | Unique |
+|--------| ----------------- | ----------- |--------|
+| id     | INTEGER           | yes         | yes    |
+| title  | TEXT              | no          | no     |
+| slug   | TEXT              | no          | yes    |
+| text   | TEXT              | no          | no     |
+| email  | TEXT              | no          | no     |
 
+You can, of course, work with an existing table if you adapt this guide accordingly.
 
 ## Create a new parent page
 
-Create a parent page called `comments` in the content folder.
+Now create a new parent page called `comments` in the content folder and add a  `comments.txt` file inside it. The file system should look like this:
 
 ```filesystem
 content/
     comments/
         comments.txt
 ```
+This file will connect the page with the `comments.php template and – more importantly – a new CommentsPage model we will create in the next steps.
+
+## Create a template and page model
+
+Create the following files:
+
+- `/site/templates/comments.php`
+- `/site/models/comments.php`.
 
 ## Connect to the database
 
@@ -56,27 +67,34 @@ return [
 ```
 
 <info>
-Here we connect to a local database, your real database should - of course - use a proper database user and secure password.
+Here we connect to a local database, your real database should, of course, use a proper database user and secure password.
 </info>
 
 ## Query the database
 
-Assuming that your database contains a table called comments, you can now query the database table in your templates like this:
+Let's check in the template that the connection to the database and the table works :
 
 ```php "/site/templates/comments.php"
+<?php
+
 $comments = Db::select('comments');
+
+foreach ($comments as $comment) {
+	dump($comment);
+};
 ```
+Provided that the table contains any data, this should output several `Kirby\Toolkit\Obj` objects (one for each database row).
 
-## Convert to child pages
+## The page model
 
-We can now convert these database entries to children of the comments parent. To do so, let's create a page model for the parent page:
+Now it is time to create a model that converts the data from the table into virtual pages:
 
 ```php "/site/models/comments.php"
 <?php
 
-use Kirby\Uuid\Uuid;
+use Kirby\Cms\Page;
 
-class CommentsPage extends Kirby\Cms\Page
+class CommentsPage extends Page
 {
     public function children(): Pages
     {
@@ -93,11 +111,11 @@ class CommentsPage extends Kirby\Cms\Page
                 'template' => 'comment',
                 'model'    => 'comment',
                 'content'  => [
+                    'title' => $comment->title(),
                     'text'  => $comment->text(),
-                    'user'  => $comment->user(),
-                    'uuid'  => Uuid::generate(),
-
-                ]
+                    'email' => $comment->email(),
+                    'uuid'  => $comment->slug(),
+               ],
             ];
         }
 
@@ -106,12 +124,12 @@ class CommentsPage extends Kirby\Cms\Page
 }
 ```
 
-Here we re-define the `children()` method of the `Page` class to return the comments from the database as children pages.
+Here we redefine the `children()` method of the `Page` class to return the comments from the database as child pages.
 
 <warning>
-Unless you have disabled UUIDs in your config, you have to pass a `uuid` field in the content array to prevent Kirby from generating the page in the file system when the `$page->uuid()` method is called.
+Unless you have disabled UUIDs in your config, you need to pass a `uuid` field in the content array to prevent Kirby from generating the page in the file system when the `$page->uuid()` method is called.
 
-If you generate the UUIDs automatically like in the example above, they will change at every load. However, if you want to reference your virtual pages anywhere with their UUID, make sure to use a unique string that does not change.
+If you generate the UUIDs automatically, as in the example above, they will change at every load. However, if you want to reference your virtual pages anywhere with their UUID, make sure to use a unique string that 1. does not change and 2. is not likely to be the same as another UUID in another page, e.g. a product SKU or something similar.
 </warning>
 
 ## Accessing the comments in the template
@@ -122,308 +140,27 @@ With this page model in place, we can now access our comments as children of the
     <?php foreach ($page->children() as $comment): ?>
     <li>
       <a href="<?= $comment->url() ?>">
-        <?= $comment->text() ?> <small>by <?= $comment->user() ?></small>
+        <?= $comment->text() ?> <small>by <?= $comment->email() ?></small>
       </a>
     </li>
     <?php endforeach ?>
 </ul>
 ```
 
-## Create the Panel blueprint
-
-We can now access these database-based pages in the Panel. To do this properly, we should create blueprints for the parent and its children first:
-
-### The parent's blueprint
-
-```yaml "/site/blueprints/pages/comments.yml"
-title: Comments
-
-sections:
-  comments:
-    label: Comments
-    type: pages
-    info: "{{ page.user }}"
-    template: comment
-
-```
-
-### The children's blueprint
-
-```yaml "/site/blueprints/pages/comment.yml"
-title: Comment
-icon: 📢
-
-options:
-  changeTitle: false
-  changeStatus: false
-  changeSlug: false
-
-fields:
-  user:
-    label: User
-    type: text
-  text:
-    label: text
-    type: textarea
-    maxlength: 600
-
-```
-
-## Create a model for the comment child page
-
-While these comments are now automatically available in the Panel, we cannot yet edit them. To make sure that they can be edited and deleted, we have to create a `CommentPage` model and modify the code of the parent model:
-
-The `CommentPage` model would need to overwrite the `writeContent()` and `readContent()` methods to get the comment details from the table instead of the text file.
-
-```php "/site/models/comment.php"
-<?php
-
-class CommentPage extends Kirby\Cms\Page
-{
-    public function writeContent(array $data, string|null $languageCode = null): bool
-    {
-        unset($data['title']);
-
-        if ($comment = Db::first('comments', '*', ['slug' => $this->slug()])) {
-            return Db::update('comments', $data, ['slug' => $this->slug()]);
-        }
-
-        $data['slug'] = $this->slug();
-        return Db::insert('comments', $data);
-    }
-
-    public function delete(bool $force = false): bool
-    {
-        return Db::delete('comments', ['slug' => $this->slug()]);
-    }
-
-    public function title(): Kirby\Content\Field
-    {
-        return $this->text()->excerpt(100)->or('New comment');
-    }
-}
-```
-
 ## A template for the individual comment
 
-If we want to access each comment on its own page, we can add an additional template for the comment:
+To access individual comments on their own pages, we add a template for the comment:
 
 ```php "/site/templates/comment.php"
 
 <?php snippet('header') ?>
 <div class="comment">
   <?= $page->text()->kt() ?>
-  <p><small>by <?= $page->user() ?></small></p>
+  <p><small>by <?= $page->email() ?></small></p>
 </div>
 <?php snippet('footer') ?>
 ```
 
-## Advanced setup
 
-If we want to enable features like changing the slug via the Panel or use the status workflow with drafts, unlisted and listed entries, we have to extend our models.
 
-But first, our table needs a new column called `status`, which can have the values `null`, `unlisted` and `listed`. We also add a title for our comments, so that we end up with the following table scheme:
 
-| Column | Datatype      | Primary Key | Unique
-| ----   | ----          | ----        | ----
-|`id`    | int           | yes         | yes
-|`text`  | VARCHAR (600) | no          | no
-|`user`  | VARCHAR (100) | no          | no
-|`slug`  | VARCHAR (185) | no          | yes
-|`title` | VARCHAR (185) | no          | no
-|`status`| VARCHAR (8)   | no          | no
-
-### Extended `comment.yml` blueprint
-
-We can show the status field in the Panel as a disabled field for control purposes, but it is not required. The options are only spelled out for clarity, `true` is the default value anyway.
-
-```yaml
-title: Comment
-icon: 📢
-
-options:
-  changeTitle: true
-  changeStatus: true
-  changeSlug: true
-
-fields:
-  user:
-    label: User
-    type: text
-  text:
-    label: text
-    type: textarea
-    maxlength: 600
-  # just for control purposes
-  status:
-    label: Status
-    type: text
-    disabled: true
-```
-
-### Extended `comments.php` model
-
-```php "/site/models/comments.php"
-<?php
-
-use Kirby\Uuid\Uuid;
-
-class CommentsPage extends Kirby\Cms\Page
-{
-    public function children(): Pages
-    {
-		    if ($this->children instanceof Pages) {
-            return $this->children;
-        }
-
-        $comments = [];
-
-        foreach (Db::select('comments') as $comment) {
-            $comments[] = [
-                'slug'     => $comment->slug(),
-                'num'      => $comment->status() === 'listed' ? 0 : null,
-                'template' => 'comment',
-                'model'    => 'comment',
-                'content'  => [
-                    'title'  => $comment->title() ?? 'New Comment',
-                    'text'   => $comment->text(),
-                    'user'   => $comment->user(),
-                    'status' => is_null($comment->status()) ? 'draft' : $comment->status(),
-										'uuid'  => Uuid::generate(),
-                ]
-            ];
-        }
-
-        return $this->children = Pages::factory($comments, $this);
-    }
-}
-```
-
-There are three differences here compared to the model above:
-
-- We set the `num` property depending on the value of the `status` field in the database.
-- We add the `status` field to the `content` array.
-- We add the `title` field to the `content` array.
-
-### The extended `comment.php` model
-
-The model for a single comment needs more significant changes:
-
-```php "/site/models/comment.php"
-<?php
-
-class CommentPage extends Kirby\Cms\Page
-{
-    public function changeSlug(string $slug, string|null $languageCode = null): static
-    {
-        // always sanitize the slug
-        $slug = Str::slug($slug);
-
-        $data['slug'] = $slug;
-
-        if ($comment = Db::first('comments', '*', ['slug' => $this->slug()])) {
-            Db::update('comments', $data, ['slug' => $this->slug()]);
-        }
-
-        return $this;
-    }
-
-    protected function changeStatusToDraft(): static
-    {
-        $data['status'] = 'null';
-
-        if ($comment = Db::first('comments', '*', ['slug' => $this->slug()])) {
-            Db::update('comments', $data, ['slug' => $this->slug()]);
-        }
-
-        return $this;
-    }
-
-    protected function changeStatusToListed(int|null $position = null): static
-    {
-        // create a sorting number for the page
-        $num = $this->createNum($position);
-
-        // don't sort if not necessary
-        if ($this->status() === 'listed' && $num === $this->num()) {
-            return $this;
-        }
-
-        $data['status'] = 'listed';
-
-        if ($comment = Db::first('comments', '*', ['slug' => $this->slug()])) {
-            Db::update('comments', $data, ['slug' => $this->slug()]);
-        }
-
-        if ($this->blueprint()->num() === 'default') {
-            $this->resortSiblingsAfterListing($num);
-        }
-
-        return $this;
-    }
-
-    protected function changeStatusToUnlisted(): static
-    {
-        if ($this->status() === 'unlisted') {
-            return $this;
-        }
-
-        $data['status'] = 'unlisted';
-
-        if ($comment = Db::first('comments', '*', ['slug' => $this->slug()])) {
-            Db::update('comments', $data, ['slug' => $this->slug()]);
-        }
-
-        $this->resortSiblingsAfterUnlisting();
-
-        return $this;
-    }
-
-    public function changeTitle(string $title, string|null $languageCode = null): static
-    {
-        $data['title'] = $title;
-
-        if ($comment = Db::first('comments', '*', ['slug' => $this->slug()])) {
-            Db::update('comments', $data, ['slug' => $this->slug()]);
-        }
-
-        return $this;
-    }
-
-    public function delete(bool $force = false): bool
-    {
-        return Db::delete('comments', ['slug' => $this->slug()]);
-    }
-
-    public function isDraft(): bool
-    {
-        return in_array($this->content()->status(), ['listed', 'unlisted']) === false;
-    }
-
-    public function writeContent(array $data, string|null $languageCode = null): bool
-    {
-        unset($data['title']);
-
-        if ($comment = Db::first('comments', '*', ['slug' => $this->slug()])) {
-            return Db::update('comments', $data, ['slug' => $this->slug()]);
-        } else {
-            $data['slug'] = $this->slug();
-            return Db::insert('comments', $data);
-        }
-    }
-}
-```
-
-We have to override all methods that are needed for changing the status and the slug, because we have to change the values for each action in the database, not in the local file system.
-
-- `changeSlug()`
-- `changeStatusToDraft()`
-- `changeStatusToListed()`
-- `changeStatusToUnlisted()`
-- `changeTitle()`
-
-Since we now have an explicit title field, we add the `changeTitle()` method and remove the `title()` method from the model, because that is no longer necessary.
-
-<info>
-When overriding Kirby's default methods in your models, your methods must use the same function syntax, i.e. parameters, type hints, return types, and return type declarations must be identical.
-</info>

--- a/content/docs/1_guide/19_virtual-content/3_content-from-database/guide.txt
+++ b/content/docs/1_guide/19_virtual-content/3_content-from-database/guide.txt
@@ -17,7 +17,7 @@ Content can also come from a database. This is particularly useful if you alread
 
 This guide covers the basic steps, such as establishing a connection to the database, accessing one or more tables, and converting database entries into children of a parent page in read-only mode. In this setup, the pages are generated dynamically from the database and cannot be modified through the Panel or written to the file system.
 
-To add advanced functionality (editing, adding, deleting pages, etc.), please refer to our (link: text: work-in-progress plugin).
+To add advanced functionality (editing, adding, deleting pages, etc.), please refer to our (link: https://github.com/getkirby/database-storage text: our database storage plugin (currently in alpha)).
 
 Our example assumes a database table called `comments` with the following schema:
 

--- a/content/docs/1_guide/19_virtual-content/8_merging-virtual-and-local-content/guide.txt
+++ b/content/docs/1_guide/19_virtual-content/8_merging-virtual-and-local-content/guide.txt
@@ -12,143 +12,286 @@ Intro: Combine virtual content with content from the file system
 
 Text:
 
-In this example, let us look at how we can combine "virtual" content with content from the file system.
+Mixing different content sources is also possible in Kirby. Let us look at how we can combine "virtual" content (data from a database, an API, etc.) with content from corresponding page folders that actually live in the file system.
 
-We will extend the (link: docs/guide/virtual-content/content-from-csv text: Content from a spreadsheet) example with content we actually add in the `content` folder, let's say because we want to add an image to each animal and some additional content.
+This example builds on our previous guide, (link: docs/guide/virtual-content/content-from-csv text: Content from a spreadsheet), so make sure to check that out first. Here, we want to mix the data from the `animals` spreadsheet with content we add in the `/content/animals` folder, for example because we want to add an image and some additional information for each animal.
 
-To this end, we add new subpages to the `/animals` parent page, using the same slugs that we generated in the `animals.php` model.
+To this end, we add new child pages to the `/animals` parent page, using the same slugs we generated in the `animals.php` model.
 
-Your content structure should then look something like this.
-
+Your content structure should then look something like this:
 
 ```filesystem
 content/
     animals/
         animals.txt
         animals.csv
-        0_potus-flavus/
+        0_potos-flavus/
             animal.txt
-            potus-flavus.jpg
+            potos-flavus.jpg
         0_sauromalus-obesus/
             animal.txt
             sauromalus-obesus.jpg
 ```
 <info>
-Make sure to prepend the folder number, because we also use the number in our model.
+Make sure to prepend the folder number, because we also use the number in our page model.
 </info>
 
-However, if we now try to fetch these newly added images in the `animal.php` template, this will have no effect. We first have to extend our model.
+However, if we now try to fetch these newly added images in the `animal.php` template, this will have no effect. Moreover, we need to make sure that we don't accidentally save virtual content in file system when we save non-virtual content via the Panel. We therefore have to extend our model. However, since Kirby 5, we also need a plugin that provides a new storage handler.
+
+## How mixed content works
+
+Conceptually, this setup combines two layers of content:
+
+- Virtual content, which is generated dynamically (in this example from a CSV file) and exists only in memory.
+- File-based content, which lives in the file system and can include files like images as well as editable fields.
+
+When a page is requested, Kirby first reads the content stored on disk and then merges it with the virtual content provided by the page model. Virtual fields complement file-based fields, but are never written back to the file system.
+
+This allows you to enrich virtual pages with assets and editable metadata, while still keeping the original data source as the single source of truth.
+
+
+## MixedStorage plugin
+In the `plugins folder, create a new folder called `mixed-storage`. Inside this folder, create an `index.php` file, a folder called `src`, and inside the `src` folder a file called `MixedStorage.php`.
+
+The file system in `/plugins` should now look like this:
+
+```filesystem
+plugins/
+    mixed-storage/
+        index.php
+        src/
+            MixedStorage.php
+```
+
+Inside `index.php`, paste the following code:
+
+```php "/site/plugins/mixed-storage/index.php"
+<?php
+
+load([
+	'kirby\\content\\mixedstorage\\mixedstorage' => __DIR__ . '/src/MixedStorage.php',
+]);
+```
+This file simply loads the `MixedStorage` class.
+
+Inside `MixedStorage.php`, paste the following code:
+
+```php "/site/plugins/mixed-storage/src/MixedStorage.php"
+<?php
+namespace Kirby\Content\MixedStorage;
+
+use Kirby\Cms\Language;
+use Kirby\Content\PlainTextStorage;
+use Kirby\Content\VersionId;
+use Kirby\Exception\Exception;
+use Kirby\Toolkit\A;
+
+class MixedStorage extends PlainTextStorage
+{
+	protected array $virtual = [];
+
+	/**
+	 * Read the original content from disk and merge it with the virtual content
+	 */
+	public function read(VersionId $versionId, Language $language): array
+	{
+		$content = parent::read($versionId, $language);
+
+		return [
+			...$this->readVirtual($versionId, $language),
+			...$content,
+		];
+	}
+
+	/**
+	 * Check if the page exists on disk and otherwise check if there is any virtual content
+	 */
+	public function exists(VersionId $versionId, Language $language): bool
+	{
+		return parent::exists($versionId, $language) || $this->readVirtual($versionId, $language) !== [];
+	}
+
+	/**
+	 * Read virtual content for a given version and language from our
+	 * in-memory storage array
+	 */
+	public function readVirtual(VersionId $versionId, Language $language): array
+	{
+		return $this->virtual[$versionId->value()][$language->code()] ?? [];
+	}
+
+	/**
+	 * Write virtual content for a given version and language to our
+	 * in-memory storage array
+	 */
+	public function writeVirtual(VersionId $versionId, Language $language, array $data): void
+	{
+		$this->virtual[$versionId->value()][$language->code()] = $data;
+	}
+
+	/**
+	 * Make sure to store only non-virtual data in the file system
+	 * @param VersionId $versionId
+	 * @param Language $language
+	 * @param array $fields
+	 * @return void
+	 * @throws Exception
+	 */
+	public function write(VersionId $versionId, Language $language, array $fields): void
+	{
+		// Get keys of virtual fields
+		$virtualKeys = array_keys($this->readVirtual($versionId, $language));
+
+		// Remove virtual fields
+		$fields = A::without($fields, $virtualKeys);
+
+		// Call parent method with only real fields
+		parent::write($versionId, $language, $fields);
+	}
+}
+```
+
+This plugin can now be used whenever we need to mix content from the file system with other data sources on a page.
+
+## Page model
 
 ```php "/site/models/animals.php"
 <?php
 
+use Kirby\Content\MixedStorage\MixedStorage;
+use Kirby\Cms\Language;
+use Kirby\Cms\Pages;
+use Kirby\Content\Storage;
+use Kirby\Content\VersionId;
+use Kirby\Toolkit\A;
+use Kirby\Uuid\Uuid;
+
 class AnimalsPage extends Page
 {
-    static $subpages = null;
+	public function children(): Pages
+	{
+		if ($this->children instanceof Pages) {
+			return $this->children;
+		}
 
-    public function subpages()
-    {
-        if (static::$subpages) {
-            return static::$subpages;
-        }
+		$csv   = csv($this->root() . '/animals.csv', ';');
+		$pages = new Pages();
 
-        return static::$subpages = Pages::factory($this->inventory()['children'], $this);
-    }
+		foreach ($csv as $animal) {
+			$slug = Str::slug($animal['Scientific Name']);
 
-    public function children()
-    {
-        if ($this->children instanceof Pages) {
-            return $this->children;
-        }
+			// No need to check for existing pages here. We can
+			// simply assume that some of them already exist on disk
+			// while others do not yet exist.
+			$page = Page::factory([
+				'slug'     => $slug,
+				'template' => 'animal',
+				'model'    => 'animal',
+				'parent'   => $this,
+				'num'      => 0,
+			]);
 
-        $csv      = csv($this->root() . '/animals.csv', ';');
-        $children = array_map(function ($animal) {
+			// Switch to the new storage handler to keep all default
+			// features for pages on disk while also adding the virtual content layer
+			$page->changeStorage(MixedStorage::class);
 
-            $slug = Str::slug($animal['Scientific Name']);
-            $page = $this->subpages()->find($slug);
+			// Write virtual content to our in-memory storage array
+			$page->storage()->writeVirtual(
+				versionId: VersionId::latest(),
+				language: Language::ensure('default'),
+				data: [
+					'title'       => $animal['Scientific Name'],
+					'commonName'  => $animal['Common Name'],
+					'description' => $animal['Description'],
+					'uuid'        => Uuid::generate(),
+				]
+			);
 
-            return [
-                'slug'     => $slug,
-                'template' => 'animal',
-                'model'    => 'animal',
-                'num'      => 0,
-                'files'    => $page ? $page->files()->toArray() : null,
-                'content'  => [
-                    'title'       => $animal['Scientific Name'],
-                    'commonName'  => $animal['Common Name'],
-                    'description' => $animal['Description'],
-                    'somefield'   => $page ? $page->somefield()->value() : null
-                ]
-            ];
-        }, $csv);
+			$pages->add($page);
+		}
 
-        return $this->children = Pages::factory($children, $this);
-    }
-
+		return $this->children = $pages;
+	}
 }
 ```
+## Blueprints
 
-First, we add a new `subpages` method that creates a new Pages object from the page's inventory array:
+To be able to see all content in the Panel, we add two blueprints, `animals.yml` for the overview page, and `animal.yml` for the individual child pages:
 
-```php
-    public function subpages()
-{
-    if (static::$subpages) {
-        return static::$subpages;
-    }
+```yaml "/site/blueprints/pages/animals.yml"
+title: Animals
 
-    return static::$subpages = Pages::factory($this->inventory()['children'], $this);
-}
-```
-This method will fetch all pages that actually exist in the filesystem.
-
-Within the closure of the `array_map` method, we now try to find a page with each slug:
-
-```php
-$slug = Str::slug($animal['Scientific Name']);
-$page = $this->subpages()->find($slug);
+sections:
+  pages:
+    type: pages
+    template: animal
 ```
 
-In the return array, we add the files and additional content if the page exists:
+```yaml "/site/blueprints/pages/animal.yml"
+title: Animal
 
-```php
-return [
-    'slug'     => $slug,
-    'template' => 'animal',
-    'model'    => 'animal',
-    'num'      => 0,
-    // add files
-    'files'    => $page ? $page->files()->toArray() : null,
-    'content'  => [
-        'title'       => $animal['Scientific Name'],
-        'commonName'  => $animal['Common Name'],
-        'description' => $animal['Description'],
-        // add additional fields
-        'habitat'     => $page ? $page->habitat()->value() : null,
-        'diet'        => $page ? $page->diet()->value() : null,
-    ]
-];
+num: alpha
+
+options:
+  changeTitle: false
+  changeSlug: false
+  duplicate: false
+  move: false
+  changeStatus: false
+columns:
+  main:
+    width: 2/3
+    fields:
+      commonName:
+        type: text
+        disabled: true
+      description:
+        type: textarea
+        disabled: true
+      wikiLink:
+        type: url
+  sidebar:
+    width: 1/3
+    sections:
+      files:
+        type: files
+
+
+
 ```
+Since we set the `title` and `slug` from virtual content, it is important to disallow changing these values in the `options` section of the blueprint. Also, changing the page status, duplicating, or moving the page does not make sense, since we are dealing with a read-only source for the virtual content, and there might not even be a "real" (i.e. file system) page for each virtual page. We also set the numbering schema to `alpha` as in our page model.
 
-And finally, we modify our subpage template to fetch the additonal content:
+We also disable the virtual fields in the blueprint, so that editors know they cannot change these fields.
+
+Depending on your page model, adapt these settings as needed. You can also add extra methods to your child page model to handle custom logic.
+
+## Child template
+Finally, let's modify our child template to fetch the additional content:
 
 ```php "/site/templates/animal.php"
 <?php snippet('header') ?>
 
-<article class="animal">
-  <h1 class="animal-scientific-name"><?= $page->title() ?></h1>
-  <p class="animal-common-name">Common name: <?= $page->commonName() ?></p>
-  <?php if ($image = $page->image()): ?>
-    <div class="animal-picture">
+  <article class="animal">
+    <h1
+      class="animal-scientific-name"><?= $page->title() ?></h1>
+    <p class="animal-common-name">Common
+      name: <?= $page->commonName() ?></p>
+    <?php if ($image = $page->image()): ?>
+      <div class="animal-picture">
         <?= $image ?>
+      </div>
+    <?php endif ?>
+    <div class="animal-description">
+      <?= $page->description()->kt() ?>
+      <?= $page->habitat()->kt() ?>
+      <?php if ($page->wikiLink()->isNotEmpty()): ?>
+        <p>
+          Read more about this interesting animal:
+          <a href="<?= $page->wikiLink() ?>"><?= $page->wikiLink() ?></a>
+        </p>
+      <?php endif ?>
     </div>
-  <?php endif ?>
-  <div class="animal-description">
-    <?= $page->description()->kt() ?>
-    <?= $page->habitat()->kt() ?>
-    <?= $page->diet()->kt() ?>
-  </div>
-</article>
+  </article>
 
 <?php snippet('footer') ?>
 ```


### PR DESCRIPTION
## Description
This PR removes the advanced section from the "Content from a database guide" and adds a link to the WIP database-storage plugin instead. We can later add a cookbook recipe that explains the concept in detail.

The second part is an update of the mixed content guide based on the MixedStorage class from the forum, plus some additions.



