### PR TITLE
Fix domain of Fabian’s website on 10 years page

### DIFF
--- a/content/10/2016/year.txt
+++ b/content/10/2016/year.txt
@@ -4,7 +4,7 @@ Text:
 
 ## Fabian
 
-While I started as a professional designer, I lost more and more track of the design world with my focus on programming. I discovered (link: https://fabianmichael.com/ text: Fabian’s design work) through his Kirby projects and instantly liked his style. It was an obvious choice to ask him to help me out. He developed a new color system for us and worked extensively on the website for Kirby 3.
+While I started as a professional designer, I lost more and more track of the design world with my focus on programming. I discovered (link: https://fabianmichael.de/ text: Fabian’s design work) through his Kirby projects and instantly liked his style. It was an obvious choice to ask him to help me out. He developed a new color system for us and worked extensively on the website for Kirby 3.
 
 (image: fabian.jpg class: avatar caption: Fabian Michael)
 


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.
-->

### Summary of changes

Just domain in link changed from `.com` to `.de`.

### Reasoning

SSL Certificate is broken on `fabianmichael.com`
