### PR TITLE
Document button label translation

### DIFF
--- a/content/docs/2_reference/7_plugins/1_extensions/0_textarea-buttons/reference-extension.txt
+++ b/content/docs/2_reference/7_plugins/1_extensions/0_textarea-buttons/reference-extension.txt
@@ -57,6 +57,28 @@ this.command("insert", (input, selection) =>
 )
 ```
 
+### Button label translation
+You can translate the button label by using the label getter:
+
+```js "site/plugins/your-plugin/index.js"
+panel.plugin("getkirby/custom-textarea-buttons", {
+  textareaButtons: {
+    highlight: {
+      get label() {
+        return panel.$t("highlight");
+      },
+      icon: "wand",
+      click: function () {
+        this.command("toggle", "<mark>", "</mark>")
+      },
+      shortcut: "m",
+    },
+  }
+});
+```
+
+(link: docs/reference/plugins/extensions/translations text: Read more about plugin translations.)
+
 ## Shortcut
 
 Each button can also define a `shortcut` which will trigger the button's `click` handler when the shortcut is pressed together with the `Cmd`/`Ctrl` key inside the textarea.

--- a/content/docs/2_reference/7_plugins/1_extensions/0_textarea-buttons/reference-extension.txt
+++ b/content/docs/2_reference/7_plugins/1_extensions/0_textarea-buttons/reference-extension.txt
@@ -58,7 +58,7 @@ this.command("insert", (input, selection) =>
 ```
 
 ### Button label translation
-You can translate the button label by using the label getter:
+You can translate the button label by defining it in the label getter. The getter ensures that the translation is already loaded when the label is rendered:
 
 ```js "site/plugins/your-plugin/index.js"
 panel.plugin("getkirby/custom-textarea-buttons", {
@@ -85,4 +85,4 @@ Each button can also define a `shortcut` which will trigger the button's `click`
 
 ## Use in the field
 
-Your new textare button won't automatically be included in the textarea's toolbar. To add it, (link: docs/reference/panel/fields/textarea#toolbar__customizing-the-toolbar text: use the `buttons` option).
+Your new textarea button won't automatically be included in the textarea's toolbar. To add it, (link: docs/reference/panel/fields/textarea#toolbar__customizing-the-toolbar text: use the `buttons` option).


### PR DESCRIPTION
## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.
-->
Docs amendment.

### Summary of changes
Added section on button label translation for textarea buttons. Found the solution here: https://github.com/getkirby/kirby/issues/5738#issuecomment-1751362801

### Reasoning
Figured this could use a more prominent place than in some comment in GitHub on some closed issue from years ago.