### PR TITLE
Feature/prefill signup data after error

### DIFF
--- a/site/controllers/partners-signup.php
+++ b/site/controllers/partners-signup.php
@@ -24,7 +24,7 @@ return function (App $kirby, Page $page) {
 			'location'   => get('location'),
 			'website'    => get('website'),
 			'address'    => get('address'),
-			'projects'   => get('projects'),
+			'projects'   => (int) get('projects'),
 			'references' => get('references'),
 			'reviewRef'  => get('downloadLink'),
 			'contact'    => get('name'),
@@ -89,7 +89,7 @@ return function (App $kirby, Page $page) {
 				}
 
 				throw new Exception(
-					"This form contains the following errors:\n" .implode("\n", $messages)
+					"This form contains the following errors:\n" . 	implode("\n" , $messages)
 				);
 			}
 
@@ -98,16 +98,16 @@ return function (App $kirby, Page $page) {
 			// submit form values to the partner hub
 			$response = Remote::post(option('partners.signupUrl'), [
 				'data' => json_encode([
-					  'fields' => [
-						  'partnerstatus' => 'open',
-						  'people'        => $people,
-						  'price'         => $visitor->currencySign() . $localizedPrice,
-						  'checkout'      => $product->checkout('buy', $checkoutData),
-						  'created'       => date('Y-m-d H:i:s'),
-						  'ip'            => $kirby->visitor()->ip(hash: true),
-						  ...$data
-					  ]
-				  ], JSON_THROW_ON_ERROR),
+					'fields' => [
+						'partnerstatus' => 'open',
+						'people'        => $people,
+						'price'         => $visitor->currencySign() . $localizedPrice,
+						'checkout'      => $product->checkout('buy', $checkoutData),
+						'created'       => date('Y-m-d H:i:s'),
+						'ip'            => $kirby->visitor()->ip(hash: true),
+						...$data
+					]
+				], JSON_THROW_ON_ERROR),
 				'headers' => [
 					'Authorization' => 'Bearer ' . option('keys.partners.signupToken'),
 					'Content-Type'  => 'application/json',
@@ -157,8 +157,10 @@ return function (App $kirby, Page $page) {
 	}
 
 	// prefill form for renewals
-	if (($renew = param('renew')) &&
-		($partner = page('partners')->find($renew))) {
+	if (
+		($renew = param('renew')) &&
+		($partner = page('partners')->find($renew))
+	) {
 			$plan   = $partner->plan()->value();
 			$people = $partner->people()->value();
 	}

--- a/site/controllers/partners-signup.php
+++ b/site/controllers/partners-signup.php
@@ -18,18 +18,20 @@ return function (App $kirby, Page $page) {
 		$peopleNum    = max(1, min(4, (int)$people));
 		$plan         = get('plan');
 		$renew        = get('renew');
-		$businessName = get('businessName');
-		$businessType = get('businessType');
-		$location     = get('location');
-		$website      = get('website');
-		$address      = get('address');
-		$projects     = (int)get('projects');
-		$references   = get('references');
-		$downloadLink = get('downloadLink');
-		$name         = get('name');
-		$email        = get('email');
-		$discord      = get('discord');
-		$notes        = get('notes');
+		$data         = [
+			'title'      => get('businessName'),
+			'business'   => get('businessType'),
+			'location'   => get('location'),
+			'website'    => get('website'),
+			'address'    => get('address'),
+			'projects'   => get('projects'),
+			'references' => get('references'),
+			'reviewRef'  => get('downloadLink'),
+			'contact'    => get('name'),
+			'email'      => get('email'),
+			'discord'    => get('discord'),
+			'notes'      => get('notes'),
+		];
 
 		try {
 			// generate checkout link data
@@ -78,38 +80,27 @@ return function (App $kirby, Page $page) {
 			}
 
 			$page->validatePlan($plan);
-			$page->validateReferences($plan, $references);
-			$page->validateWebsite($website);
-			$page->validateEmail($email);
-			$page->validateBusinessType($businessType);
-			$page->validateProjects($projects, $plan);
-			$page->validateDownloadLink($downloadLink);
+			$page->validateReferences($plan, $data['references']);
+			$page->validateWebsite($data['website']);
+			$page->validateEmail($data['email']);
+			$page->validateBusinessType($data['business']);
+			$page->validateProjects($data['projects'], $plan);
+			$page->validateDownloadLink($data['reviewRef']);
 
 			// submit form values to the partner hub
 			$response = Remote::post(option('partners.signupUrl'), [
 				'data' => json_encode([
-					'fields' => [
-						'title'         => $businessName,
-						'partnerstatus' => 'open',
-						'plan'          => $plan,
-						'people'        => $people,
-						'price'         => $visitor->currencySign() . $localizedPrice,
-						'checkout'      => $product->checkout('buy', $checkoutData),
-						'business'      => $businessType,
-						'website'       => $website,
-						'contact'       => $name,
-						'email'         => $email,
-						'discord'       => $discord,
-						'location'      => $location,
-						'address'       => $address,
-						'projects'      => $projects,
-						'references'    => $references,
-						'reviewRef'     => $downloadLink,
-						'notes'         => $notes,
-						'created'       => date('Y-m-d H:i:s'),
-						'ip'            => $kirby->visitor()->ip(hash: true),
-					]
-				], JSON_THROW_ON_ERROR),
+					  'fields' => [
+						  'partnerstatus' => 'open',
+						  'plan'          => $plan,
+						  'people'        => $people,
+						  'price'         => $visitor->currencySign() . $localizedPrice,
+						  'checkout'      => $product->checkout('buy', $checkoutData),
+						  'created'       => date('Y-m-d H:i:s'),
+						  'ip'            => $kirby->visitor()->ip(hash: true),
+						  ... $data
+					  ]
+				  ], JSON_THROW_ON_ERROR),
 				'headers' => [
 					'Authorization' => 'Bearer ' . option('keys.partners.signupToken'),
 					'Content-Type'  => 'application/json',
@@ -176,5 +167,6 @@ return function (App $kirby, Page $page) {
 		'questions' => $page->find('answers')->children(),
 		'regular'   => Product::PartnerRegular,
 		'renew'     => $partner ?? null,
+		'data'      => $data ?? [],
 	];
 };

--- a/site/controllers/partners-signup.php
+++ b/site/controllers/partners-signup.php
@@ -24,7 +24,7 @@ return function (App $kirby, Page $page) {
 			'location'   => get('location'),
 			'website'    => get('website'),
 			'address'    => get('address'),
-			'projects'   => (int) get('projects'),
+			'projects'   => (int)get('projects'),
 			'references' => get('references'),
 			'reviewRef'  => get('downloadLink'),
 			'contact'    => get('name'),
@@ -89,7 +89,7 @@ return function (App $kirby, Page $page) {
 				}
 
 				throw new Exception(
-					"This form contains the following errors:\n" . 	implode("\n" , $messages)
+					"This form contains the following errors:\n" . implode("\n" , $messages)
 				);
 			}
 
@@ -161,8 +161,8 @@ return function (App $kirby, Page $page) {
 		($renew = param('renew')) &&
 		($partner = page('partners')->find($renew))
 	) {
-			$plan   = $partner->plan()->value();
-			$people = $partner->people()->value();
+		$plan   = $partner->plan()->value();
+		$people = $partner->people()->value();
 	}
 
 	/**

--- a/site/controllers/partners-signup.php
+++ b/site/controllers/partners-signup.php
@@ -79,17 +79,16 @@ return function (App $kirby, Page $page) {
 				exit('OK');
 			}
 
-			$errors   = $page->validate($data);
-			$messages = $page->getMessages();
+			$errors = $page->validate($data);
 
 			if (count($errors)) {
-				foreach ($errors as $key => $value) {
+				foreach ($errors as $field => $message) {
 					// Clear form data for invalid fields
-					unset($data[$key]);
+					unset($data[$field]);
 				}
 
 				throw new Exception(
-					"This form contains the following errors:\n" . implode("\n" , $messages)
+					"This form contains the following errors:\n" . implode("\n" , array_values($errors))
 				);
 			}
 

--- a/site/controllers/partners-signup.php
+++ b/site/controllers/partners-signup.php
@@ -16,9 +16,9 @@ return function (App $kirby, Page $page) {
 		$timestamp    = get('timestamp');
 		$people       = get('people');
 		$peopleNum    = max(1, min(4, (int)$people));
-		$plan         = get('plan');
 		$renew        = get('renew');
 		$data         = [
+			'plan'       => get('plan') ?? 'certified',
 			'title'      => get('businessName'),
 			'business'   => get('businessType'),
 			'location'   => get('location'),
@@ -35,7 +35,7 @@ return function (App $kirby, Page $page) {
 
 		try {
 			// generate checkout link data
-			$product = Product::from('partner-' . $plan);
+			$product = Product::from('partner-' . $data['plan']);
 			$price   = $product->price();
 
 			$eurPrice       = $product->price('EUR')->regular($peopleNum);
@@ -79,26 +79,33 @@ return function (App $kirby, Page $page) {
 				exit('OK');
 			}
 
-			$page->validatePlan($plan);
-			$page->validateReferences($plan, $data['references']);
-			$page->validateWebsite($data['website']);
-			$page->validateEmail($data['email']);
-			$page->validateBusinessType($data['business']);
-			$page->validateProjects($data['projects'], $plan);
-			$page->validateDownloadLink($data['reviewRef']);
+			$errors   = $page->validate($data);
+			$messages = $page->getMessages();
+
+			if (count($errors)) {
+				foreach ($errors as $key => $value) {
+					// Clear form data for invalid fields
+					unset($data[$key]);
+				}
+
+				throw new Exception(
+					"This form contains the following errors:\n" .implode("\n", $messages)
+				);
+			}
+
+
 
 			// submit form values to the partner hub
 			$response = Remote::post(option('partners.signupUrl'), [
 				'data' => json_encode([
 					  'fields' => [
 						  'partnerstatus' => 'open',
-						  'plan'          => $plan,
 						  'people'        => $people,
 						  'price'         => $visitor->currencySign() . $localizedPrice,
 						  'checkout'      => $product->checkout('buy', $checkoutData),
 						  'created'       => date('Y-m-d H:i:s'),
 						  'ip'            => $kirby->visitor()->ip(hash: true),
-						  ... $data
+						  ...$data
 					  ]
 				  ], JSON_THROW_ON_ERROR),
 				'headers' => [
@@ -150,12 +157,12 @@ return function (App $kirby, Page $page) {
 	}
 
 	// prefill form for renewals
-	if ($renew = param('renew')) {
-		if ($partner = page('partners')->find($renew)) {
+	if (($renew = param('renew')) &&
+		($partner = page('partners')->find($renew))) {
 			$plan   = $partner->plan()->value();
 			$people = $partner->people()->value();
-		}
 	}
+
 	/**
 	 * @var Page|null $renew
 	 */

--- a/site/models/partners-signup.php
+++ b/site/models/partners-signup.php
@@ -6,28 +6,24 @@ use Kirby\Toolkit\V;
 
 class PartnersSignupPage extends Page
 {
-	private array $messages = [];
-
 	public function validate(array $data): array
 	{
-		$this->resetMessages();
-
 		$errors = [
-			'plan'         => $this->validatePlan($data['plan']),
-			'references'   => $this->validateReferences($data['plan'], $data['references']),
-			'website'      => $this->validateWebsite($data['website']),
-			'email'        => $this->validateEmail($data['email']),
-			'businessType' => $this->validateBusinessType($data['business']),
-			'projects'     => $this->validateProjects($data['projects'], $data['plan']),
-			'downloadLink' => $this->validateDownloadLink($data['reviewRef']),
+			'plan'       => $this->validatePlan($data['plan']),
+			'references' => $this->validateReferences($data['plan'], $data['references']),
+			'website'    => $this->validateWebsite($data['website']),
+			'email'      => $this->validateEmail($data['email']),
+			'business'   => $this->validateBusinessType($data['business']),
+			'projects'   => $this->validateProjects($data['projects'], $data['plan']),
+			'reviewRef'  => $this->validateDownloadLink($data['reviewRef']),
 		];
 
-		return array_filter($errors, fn($error) => $error === false);
+		return array_filter($errors, fn($error) => $error !== true);
 	}
 	/**
 	 * @throws Exception
 	 */
-	public function validateReferences(string $plan, string $references): bool
+	public function validateReferences(string $plan, string $references): string|bool
 	{
 		$links        = array_unique(preg_split('/[\s,]+/', $references, -1, PREG_SPLIT_NO_EMPTY));
 		$projectCount = $plan === 'regular' ? 2 : 4;
@@ -35,14 +31,12 @@ class PartnersSignupPage extends Page
 		$links = array_unique($links);
 
 		if (count($links) < $projectCount) {
-			$this->messages[] = 'A minimum number of ' . $projectCount . ' unique references is required';
-			return false;
+			return 'A minimum number of ' . $projectCount . ' unique references is required';
 		}
 
 		foreach ($links as $referenceLink) {
 			if (V::url($referenceLink) === false || Str::contains($referenceLink, 'example')) {
-				$this->messages[] = 'At least one of the URLs provided is not valid';
-				return false;
+				return 'At least one of the URLs provided is not valid';
 			}
 		}
 
@@ -52,67 +46,60 @@ class PartnersSignupPage extends Page
 	/**
 	 * @throws Exception
 	 */
-	public function validateWebsite(string $website): bool
+	public function validateWebsite(string $website): string|bool
 	{
 		if (empty($website)) {
-			$this->messages[] = 'The website field may not be empty';
-			return false;
+			return 'The website field may not be empty';
 		}
 
 		if (V::url($website) === false) {
-			$this->messages[] = 'Please make sure to provide a valid website URL';
-			return false;
+			return 'Please make sure to provide a valid website URL';
 		}
 
 		if (Str::contains($website, 'example')) {
-			$this->messages[] = 'Please provide a valid website name';
-			return false;
+			return 'Please provide a valid website name';
 		}
 
 		return true;
 	}
 
-	public function validateEmail(string $email): bool
+	public function validateEmail(string $email): string|bool
 	{
 		if (V::email($email) === false || Str::contains($email, 'example')) {
-			$this->messages[] = 'Please provide a valid email';
-			return false;
+			return 'Please provide a valid email';
 		}
 
 		return true;
 	}
 
-	public function validateBusinessType(string $businessType): bool
+	public function validateBusinessType(string $businessType): string|bool
 	{
 		if (is_numeric($businessType) || preg_match('/^[0-9_\-@#$]/', $businessType)) {
-			$this->messages[] = 'Please provide a valid business name';
-			return false;
+			return 'Please provide a valid business name';
 		}
 
 		return true;
 	}
 
-	public function validatePlan(string $plan): bool
+	public function validatePlan(string $plan): string|bool
 	{
 		if (in_array($plan, ['regular', 'certified']) === false) {
-			$this->messages[] = 'Please provide a valid plan';
-			return false;
+			return 'Please provide a valid plan';
 		}
 
 		return true;
 	}
 
-	public function validateDownloadLink(?string $link): bool
+	public function validateDownloadLink(?string $link): string|bool
 	{
 		if ($link && $link !== '' && V::url($link) === false) {
-			$this->messages[] = 'Please provide a valid download URL or leave the field empty';
-			return false;
+			return 'Please provide a valid download URL or leave the field empty';
 		}
 
 		return true;
 	}
 
-	public function validateProjects(int $projects, $plan): bool
+	public function validateProjects(int $projects, $plan): string|bool
 	{
 		$rules = [
 			'regular'   => 2,
@@ -120,8 +107,7 @@ class PartnersSignupPage extends Page
 		];
 
 		if ($projects < $rules[$plan]) {
-			$this->messages[] = 'The number of projects does not match the minimum number of required projects for the selected plan';
-			return false;
+			return 'The number of projects does not match the minimum number of required projects for the selected plan';
 		}
 
 		return true;

--- a/site/models/partners-signup.php
+++ b/site/models/partners-signup.php
@@ -6,72 +6,113 @@ use Kirby\Toolkit\V;
 
 class PartnersSignupPage extends Page
 {
+	private array $messages = [];
+
+	public function validate(array $data): array
+	{
+		$this->resetMessages();
+
+		$errors = [
+			'plan'         => $this->validatePlan($data['plan']),
+			'references'   => $this->validateReferences($data['plan'], $data['references']),
+			'website'      => $this->validateWebsite($data['website']),
+			'email'        => $this->validateEmail($data['email']),
+			'businessType' => $this->validateBusinessType($data['business']),
+			'projects'     => $this->validateProjects($data['projects'], $data['plan']),
+			'downloadLink' => $this->validateDownloadLink($data['reviewRef']),
+		];
+
+		return array_filter($errors, fn($error) => $error === false);
+	}
 	/**
 	 * @throws Exception
 	 */
-	public function validateReferences(string $plan, string $references): void
+	public function validateReferences(string $plan, string $references): bool
 	{
-		$links = preg_split('/[\s,]+/', $references, -1, PREG_SPLIT_NO_EMPTY);
+		$links        = array_unique(preg_split('/[\s,]+/', $references, -1, PREG_SPLIT_NO_EMPTY));
 		$projectCount = $plan === 'regular' ? 2 : 4;
 
+		$links = array_unique($links);
+
 		if (count($links) < $projectCount) {
-			throw new Exception('A minimum number of ' . $projectCount . ' references is required');
+			$this->messages[] = 'A minimum number of ' . $projectCount . ' unique references is required';
+			return false;
 		}
 
 		foreach ($links as $referenceLink) {
-			if (V::url($referenceLink) === false) {
-				throw new Exception('At least one of the URLs provided is not valid');
+			if (V::url($referenceLink) === false || Str::contains($referenceLink, 'example')) {
+				$this->messages[] = 'At least one of the URLs provided is not valid';
+				return false;
 			}
 		}
+
+		return true;
 	}
 
 	/**
 	 * @throws Exception
 	 */
-	public function validateWebsite(string $website): void
+	public function validateWebsite(string $website): bool
 	{
 		if (empty($website)) {
-			throw new Exception('The website field may not be empty');
+			$this->messages[] = 'The website field may not be empty';
+			return false;
 		}
 
 		if (V::url($website) === false) {
-			throw new Exception('Please make sure to provide a valid website URL');
+			$this->messages[] = 'Please make sure to provide a valid website URL';
+			return false;
 		}
 
 		if (Str::contains($website, 'example')) {
-			throw new Exception('Please provide a valid website name');
+			$this->messages[] = 'Please provide a valid website name';
+			return false;
 		}
+
+		return true;
 	}
 
-	public function validateEmail(string $email): void
+	public function validateEmail(string $email): bool
 	{
 		if (V::email($email) === false || Str::contains($email, 'example')) {
-			throw new Exception('Please provide a valid email');
+			$this->messages[] = 'Please provide a valid email';
+			return false;
 		}
+
+		return true;
 	}
 
-	public function validateBusinessType(string $businessType): void
+	public function validateBusinessType(string $businessType): bool
 	{
 		if (is_numeric($businessType) || preg_match('/^[0-9_\-@#$]/', $businessType)) {
-			throw new Exception('Please provide a valid business name');
+			$this->messages[] = 'Please provide a valid business name';
+			return false;
 		}
+
+		return true;
 	}
 
-	public function validatePlan(string $plan): void
+	public function validatePlan(string $plan): bool
 	{
 		if (in_array($plan, ['regular', 'certified']) === false) {
-			throw new Exception('Please provide a valid plan');
+			$this->messages[] = 'Please provide a valid plan';
+			return false;
 		}
+
+		return true;
 	}
 
-	public function validateDownloadLink(?string $link): void
+	public function validateDownloadLink(?string $link): bool
 	{
 		if ($link && $link !== '' && V::url($link) === false) {
-			throw new Exception('Please provide a valid download URL or leave the field empty');
+			$this->messages[] = 'Please provide a valid download URL or leave the field empty';
+			return false;
 		}
+
+		return true;
 	}
 
-	public function validateProjects(int $projects, $plan): void
+	public function validateProjects(int $projects, $plan): bool
 	{
 		$rules = [
 			'regular'   => 2,
@@ -79,10 +120,21 @@ class PartnersSignupPage extends Page
 		];
 
 		if ($projects < $rules[$plan]) {
-			throw new Exception(
-			'The number of projects does not match the minimum number of required projects for the selected plan'
-			);
+			$this->messages[] = 'The number of projects does not match the minimum number of required projects for the selected plan';
+			return false;
 		}
+
+		return true;
+	}
+
+	public function getMessages(): array
+	{
+		return $this->messages;
+	}
+
+	private function resetMessages(): void
+	{
+		$this->messages = [];
 	}
 
 }

--- a/site/models/partners-signup.php
+++ b/site/models/partners-signup.php
@@ -112,15 +112,4 @@ class PartnersSignupPage extends Page
 
 		return true;
 	}
-
-	public function getMessages(): array
-	{
-		return $this->messages;
-	}
-
-	private function resetMessages(): void
-	{
-		$this->messages = [];
-	}
-
 }

--- a/site/models/partners-signup.php
+++ b/site/models/partners-signup.php
@@ -99,7 +99,7 @@ class PartnersSignupPage extends Page
 		return true;
 	}
 
-	public function validateProjects(int $projects, $plan): string|bool
+	public function validateProjects(int $projects, string $plan): string|bool
 	{
 		$rules = [
 			'regular'   => 2,

--- a/site/snippets/templates/partners-signup/signup.php
+++ b/site/snippets/templates/partners-signup/signup.php
@@ -100,6 +100,15 @@
 		@submit="submit"
 	>
 		<input type="hidden" name="timestamp" :value="locale.timestamp">
+		<div style="position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border-width:0;">
+			<label for="date_of_birth">Date of birth</label>
+			<input
+				type="text"
+				aria-hidden="true"
+				tabindex="-1"
+				name="date_of_birth"
+			>
+		</div>
 
 		<div>
 			<fieldset class="mb-6">

--- a/site/snippets/templates/partners-signup/signup.php
+++ b/site/snippets/templates/partners-signup/signup.php
@@ -100,15 +100,7 @@
 		@submit="submit"
 	>
 		<input type="hidden" name="timestamp" :value="locale.timestamp">
-		<div style="position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border-width:0;">
-			<label for="date_of_birth">Date of birth</label>
-			<input
-				type="text"
-				aria-hidden="true"
-				tabindex="-1"
-				name="date_of_birth"
-			>
-		</div>
+
 		<div>
 			<fieldset class="mb-6">
 				<legend class="label">Partnership</legend>
@@ -299,24 +291,24 @@ createApp({
 		plan: "<?= $plan ?>",
 
 		// listing fields
-		businessName: "",
-		businessType: "",
-		location: "",
+		businessName: "<?= esc($data['title'] ?? '', 'js') ?>",
+		businessType: "<?= esc($data['business'] ?? '', 'js') ?>",
+		location: "<?= esc($data['location'] ?? '', 'js') ?>",
 
 		// business info
-		website: "",
-		address: "",
-		projects: "",
-		references: "",
-		downloadLink: "",
+		website: "<?= esc($data['website'] ?? '', 'js') ?>",
+		address: "<?= esc($data['address'] ?? '', 'js') ?>",
+		projects: "<?= esc($data['projects'] ?? '', 'js') ?>",
+		references: "<?= esc($data['references'] ?? '', 'js') ?>",
+		downloadLink: "<?= esc($data['reviewRef'] ?? '', 'js') ?>",
 
 		// contact info
-		name: "",
-		email: "",
-		discord: "",
+		name: "<?= esc($data['contact'] ?? '', 'js') ?>",
+		email: "<?= esc($data['email'] ?? '', 'js') ?>",
+		discord: "<?= esc($data['discord'] ?? '', 'js') ?>",
 
 		// notes
-		notes: "",
+		notes: "<?= esc($data['notes'] ?? '', 'js') ?>",
 	},
 
 	// dynamic props

--- a/site/snippets/templates/partners-signup/signup.php
+++ b/site/snippets/templates/partners-signup/signup.php
@@ -296,8 +296,8 @@ createApp({
 	// user-generated props
 	form: {
 		// plan
-		people: "<?= $people ?? '1' ?>",
-		plan: "<?= $data['plan'] ?? 'certified' ?>",
+		people: "<?= esc($people ?? '1', 'js') ?>",
+		plan: "<?= esc($data['plan'] ?? 'certified', 'js') ?>",
 
 		// listing fields
 		businessName: "<?= esc($data['title'] ?? '', 'js') ?>",

--- a/site/snippets/templates/partners-signup/signup.php
+++ b/site/snippets/templates/partners-signup/signup.php
@@ -112,7 +112,7 @@
 							v-model="form.plan"
 							value="regular"
 							:disabled="view === 'details' && form.plan !== 'regular'"
-							<?php if ($plan !== 'certified'): ?>checked<?php endif ?>
+							<?php if (($data['plan'] ?? 'certified') !== 'certified'): ?>checked<?php endif ?>
 						/>
 						Regular partner
 					</label>
@@ -123,7 +123,7 @@
 							v-model="form.plan"
 							value="certified"
 							:disabled="view === 'details' && form.plan !== 'certified'"
-							<?php if ($plan === 'certified'): ?>checked<?php endif ?>
+							<?php if (($data['plan'] ?? 'certified') === 'certified'): ?>checked<?php endif ?>
 						/>
 						Certified partner
 					</label>
@@ -184,7 +184,7 @@
 				<h3 class="label">Your listing</h3>
 				<div class="rounded bg-light" style="padding: 2px">
 					<?php snippet('templates/partners-signup/preview', [
-						'plan'  => $plan,
+						'plan'  => $data['plan'] ?? 'certified',
 						'renew' => $renew
 					]) ?>
 				</div>
@@ -197,7 +197,7 @@
 		>
 			<div>
 				<?php snippet('templates/partners-signup/info', [
-					'plan'   => $plan,
+					'plan'   => $data['plan'] ?? 'certified',
 					'people' => $people ?? 1,
 					'renew'  => $renew
 				]) ?>
@@ -231,7 +231,7 @@
 			class="flex flex-column justify-between right-column"
 		>
 			<div>
-				<?php snippet('templates/partners-signup/form', ['plan' => $plan]) ?>
+				<?php snippet('templates/partners-signup/form', ['plan' => $data['plan'] ?? 'certified']) ?>
 			</div>
 
 			<div class="submit-buttons">
@@ -288,7 +288,7 @@ createApp({
 	form: {
 		// plan
 		people: "<?= $people ?? '1' ?>",
-		plan: "<?= $plan ?>",
+		plan: "<?= $data['plan'] ?? 'certified' ?>",
 
 		// listing fields
 		businessName: "<?= esc($data['title'] ?? '', 'js') ?>",


### PR DESCRIPTION
## Description
This PR makes makes sure to preserve user input data in case of form errors, so that users don't have to re-enter valid information. Invalid fields are cleared, though.

The validation method have been moved into a parent method, and now return a boolean. The purpose is to return multiple error messages at the top of the page if needed.



