### PR TITLE
feat: Do not serve dotfiles in nginx subdirectories

### DIFF
--- a/content/docs/3_cookbook/0_development-deployment/0_nginx/cookbook-recipe.txt
+++ b/content/docs/3_cookbook/0_development-deployment/0_nginx/cookbook-recipe.txt
@@ -58,7 +58,7 @@ server {
   add_header X-Content-Type-Options nosniff;
 
   rewrite ^/(content|site|kirby)/(.*)$ /error last;
-  rewrite ^/\.(?!well-known/) /error last;
+  rewrite /\.(?!well-known/) /error last;
   rewrite ^/(?!app\.webmanifest)[^/]+$ /index.php last;
 
   location / {


### PR DESCRIPTION
## Description

This PR updates the nginx recipe to redirect not only dotfiles in the root, but in subdirectories, too.

### Summary of changes

Update of nginx example config.

### Reasoning

I stumbled upon this when moving the `accounts` folder outside of `site`: As it was no longer caught by `^/(content|site|kirby)/(.*)$`, I was able to access the `.htpasswd` files.


