### PR TITLE
refact: Remove timestamp honeypot from partners signup

### DIFF
--- a/site/controllers/partners-signup.php
+++ b/site/controllers/partners-signup.php
@@ -6,14 +6,12 @@ use Kirby\Buy\Product;
 use Kirby\Cms\App;
 use Kirby\Cms\Page;
 use Kirby\Discord\Discord;
-use Kirby\Honey\Time;
 use Kirby\Http\Remote;
 
 return function (App $kirby, Page $page) {
 	// submitted form
 	if ($kirby->request()->is('POST') === true) {
 		$visitor      = Paddle::visitor();
-		$timestamp    = get('timestamp');
 		$people       = get('people');
 		$peopleNum    = max(1, min(4, (int)$people));
 		$renew        = get('renew');
@@ -67,11 +65,6 @@ return function (App $kirby, Page $page) {
 				go($checkout);
 				return;
 			}
-
-			// prevent submissions faster than 1 minute (spam protection)
-			// (only needed for new applications because otherwise
-			// there will be a redirect to Paddle)
-			Time::validate($timestamp);
 
 			// check anti-spam honeypot
 			if (get('date_of_birth')) {

--- a/site/routes/partners.php
+++ b/site/routes/partners.php
@@ -2,7 +2,6 @@
 
 use Kirby\Buy\Paddle;
 use Kirby\Buy\Product;
-use Kirby\Honey\Time;
 use Kirby\Http\Response;
 
 return [
@@ -31,7 +30,6 @@ return [
 						'4+' => $certified->price()->regular(4),
 					],
 				],
-				'timestamp' => Time::get(),
 			], JSON_UNESCAPED_UNICODE);
 
 			return Response::json(

--- a/site/snippets/templates/partners-signup/signup.php
+++ b/site/snippets/templates/partners-signup/signup.php
@@ -99,7 +99,6 @@
 		style="--columns: 2; --columns-md: 1; gap: 0"
 		@submit="submit"
 	>
-		<input type="hidden" name="timestamp" :value="locale.timestamp">
 		<div style="position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border-width:0;">
 			<label for="date_of_birth">Date of birth</label>
 			<input
@@ -290,7 +289,6 @@ createApp({
 				"4+": <?= $certified->price()->regular(4) ?>,
 			}
 		},
-		timestamp: "",
 	},
 
 	// user-generated props


### PR DESCRIPTION
## Merge before

- [x] #2542

## Description
<!--
A clear and concise description of the PR.
Use this section for review hints, explanations or discussion points/todos.
-->

### Summary of changes

Timestamp honeypot is removed from partner signup form; partner lead form keeps it for now

### Reasoning

Now covered by rate limiting; timestamp check could prevent quick form resubmissions after errors