### PR TITLE
docs: Clarify collection context for page navigation

### DIFF
--- a/content/docs/2_reference/4_objects/cms/0_page/0_has-next/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_has-next/reference-classmethod.txt
@@ -8,6 +8,8 @@ if ($page->hasNext()) {
 
 ### With collection as argument
 
+By default, this method checks the page's siblings collection. Collection operations such as sorting, filtering, adding or merging return a new collection and don't change the page's sibling context. Pass the resulting collection to check whether there is a next page in that specific collection.
+
 ```php
 $collection = $page->siblings()->sortBy('date', 'desc');
 

--- a/content/docs/2_reference/4_objects/cms/0_page/0_has-prev/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_has-prev/reference-classmethod.txt
@@ -8,6 +8,8 @@ if ($page->hasPrev()) {
 
 ### With collection as argument
 
+By default, this method checks the page's siblings collection. Collection operations such as sorting, filtering, adding or merging return a new collection and don't change the page's sibling context. Pass the resulting collection to check whether there is a previous page in that specific collection.
+
 ```php
 <?php
 $collection = $page->siblings()->sortBy('date', 'desc');

--- a/content/docs/2_reference/4_objects/cms/0_page/0_next/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_next/reference-classmethod.txt
@@ -6,7 +6,9 @@ Examples:
 <?php endif ?>
 ```
 
-### Pass a collection
+### With collection as argument
+
+By default, this method uses the page's siblings collection. Collection operations such as sorting, filtering, adding or merging return a new collection and don't change the page's sibling context. Pass the resulting collection to get the next page in that specific collection.
 
 ```php
 <?php

--- a/content/docs/2_reference/4_objects/cms/0_page/0_prev/reference-classmethod.txt
+++ b/content/docs/2_reference/4_objects/cms/0_page/0_prev/reference-classmethod.txt
@@ -8,6 +8,8 @@ Examples:
 
 ### With collection as argument
 
+By default, this method uses the page's siblings collection. Collection operations such as sorting, filtering, adding or merging return a new collection and don't change the page's sibling context. Pass the resulting collection to get the previous page in that specific collection.
+
 ```php
 <?php
 $collection = $page->siblings()->listed()->sortBy('date', 'desc');


### PR DESCRIPTION
## Description

Clarifies that `prev()`, `next()`, `hasPrev()` and `hasNext()` use the page's original siblings collection by default.

When a collection is sorted, filtered, added to or merged, the resulting collection must be passed explicitly to these methods.

- Fixes #993


