### PR TITLE
docs: Document site files in image KirbyTag

### DIFF
--- a/content/docs/2_reference/1_text/0_kirbytags/0_image/reference-kirbytag.txt
+++ b/content/docs/2_reference/1_text/0_kirbytags/0_image/reference-kirbytag.txt
@@ -37,6 +37,16 @@ You can customize the defaults of this tag's attributes via the (link: docs/refe
 (\image: myawesomepicture.jpg)
 ```
 
+### Image from the site files
+
+To embed an image stored directly in the `/content` folder, use only its filename. The `/content` part of the path is assumed:
+
+```kirbytext
+(\image: myawesomepicture.jpg)
+```
+
+Kirby first searches the current page for the file. If the page has a file with the same filename, it takes precedence over the site file.
+
 ### Image of another internal page
 
 ```kirbytext


### PR DESCRIPTION
## Description

Documents how to embed site files stored directly in the `/content` folder with the image KirbyTag.

Also clarifies that:

- The `/content` part of the path is assumed
- Only the filename needs to be passed
- A file on the current page takes precedence over a site file with the same filename

### Changelog

- Fixes #2476