### PR TITLE
Update reference-article with options details

### DIFF
--- a/content/docs/2_reference/3_panel/1_blueprints/0_file/reference-article.txt
+++ b/content/docs/2_reference/3_panel/1_blueprints/0_file/reference-article.txt
@@ -141,6 +141,9 @@ create:
   height: 500
   crop: true
 ```
+<info>
+`create` uses the thumbs-pipeline, so it accepts all `thumbs`-options (like `quality`, `sharpen`, `grayscale`, etc.)
+</info>
 
 ### Convert image formats on upload
 


### PR DESCRIPTION
Added information about the `create` option.
I had to do some digging to find that `create` passes these options through - good to know!


