### PR TITLE
docs: Fix and complete permission keys

### DIFF
--- a/content/docs/2_reference/3_panel/1_blueprints/0_user/reference-article.txt
+++ b/content/docs/2_reference/3_panel/1_blueprints/0_user/reference-article.txt
@@ -195,13 +195,27 @@ The `permissions` option can be used to restrict access to certain actions for t
 | `system`| `true`/`false` |
 | `users` | `true`/`false`|
 
-#### Example: Prevent accessing user management and settings
+#### Example: Prevent accessing user management and system settings
 
 ```yaml
 permissions:
   access:
-    settings: false
+    system: false
     users: false
+```
+
+<info>
+`access.settings` was renamed to `access.system` in Kirby 3.6. The old key no longer has any effect.
+</info>
+
+#### Custom Panel areas
+
+Plugins that register a Panel area automatically add an `access.<areaId>` key, so custom areas can be restricted the same way as core ones:
+
+```yaml
+permissions:
+  access:
+    todos: false
 ```
 
 ### `files`
@@ -214,6 +228,7 @@ permissions:
 | `create` | `true`/`false` |
 | `delete` | `true`/`false` |
 | `list` | `true`/`false` |
+| `read` | `true`/`false` |
 | `replace` | `true`/`false` |
 | `sort` | `true`/`false` |
 | `update` | `true`/`false` |
@@ -223,6 +238,23 @@ permissions:
 ```yaml
 permissions:
   files:
+    delete: false
+```
+
+### `languages`
+
+| Option | Value |
+|----    | ---- |
+| `create` | `true`/`false` |
+| `delete` | `true`/`false` |
+| `update` | `true`/`false` |
+
+#### Example: Prevent creating and deleting languages
+
+```yaml
+permissions:
+  languages:
+    create: false
     delete: false
 ```
 
@@ -241,6 +273,7 @@ permissions:
 | `list` | `true`/`false` |
 | `move` | `true`/`false` |
 | `preview` | `true`/`false` |
+| `read` | `true`/`false` |
 | `sort` | `true`/`false` |
 | `update` | `true`/`false` |
 
@@ -260,6 +293,7 @@ permissions:
 |----    | ---- |
 | `access` | `true`/`false` |
 | `changeTitle` | `true`/`false` |
+| `preview` | `true`/`false` |
 | `update` | `true`/`false` |
 
 ### `users`

--- a/content/docs/2_reference/7_plugins/1_extensions/0_permissions/reference-extension.txt
+++ b/content/docs/2_reference/7_plugins/1_extensions/0_permissions/reference-extension.txt
@@ -6,6 +6,26 @@ Text:
 
 If you want to make the permissions for different actions of your plugin configurable by user role, you can register the available actions with the `permissions` extension.
 
+## Custom Panel areas
+
+If your plugin registers a Panel area, it automatically gets an `access.<areaId>` permission. You do not need the `permissions` extension for that.
+
+```php "/site/plugins/todos/index.php"
+Kirby::plugin('my/todos', [
+    'areas' => [
+        'todos' => fn () => [ /* ... */ ]
+    ]
+]);
+```
+
+```yaml "/site/blueprints/users/editor.yml"
+permissions:
+  access:
+    todos: false
+```
+
+Use the `permissions` extension only for actions inside your plugin (create, delete, publish …), not for access to the area itself.
+
 ## PHP definition
 
 Each available action needs to be set with the default permission value. The default value is used if the user's role does not specify the permissions for that action.
@@ -27,6 +47,8 @@ All permissions of the Kirby core are set to `true` by default. Only use the def
 ## Usage in the user blueprint
 
 The permissions can now be set in the user blueprint for each role (just like the (link: docs/guide/users/permissions text: core permissions)).
+
+Your permissions are grouped under a category named after the plugin, with the slash replaced by a dot: `my/permissionPlugin` becomes `my.permissionPlugin`. Use exactly that key in the user blueprint.
 
 ```yaml "/site/blueprints/users/editor.yml"
 title: Editor


### PR DESCRIPTION
The user blueprint reference had `access.settings` in an example. That key was renamed to `system` in 3.6 and the fallback was dropped in 3.8, so it has done nothing for years — but people kept copying it from the docs. This fixes that and fills in a few gaps around it.

Docs follow-up to getkirby/kirby#8319.

## Changes

**User blueprint reference** (`/docs/reference/panel/blueprints/user#permissions`)

- Fixed the `access` example: `settings: false` → `system: false`
- Added a note that `access.settings` was renamed in 3.6 and no longer works
- Added a short section about custom Panel areas (`access.<areaId>`)

**Permissions extension** (`/docs/reference/plugins/extensions/permissions`)

- Added a note that Panel areas get their permission automatically — you don't need this extension for them
- Explained where the category name comes from (`my/plugin` → `my.plugin`)
- Added an "Undefined permissions" section, since the deprecation warning links here

## Missing keys

I know these are outside the scope of getkirby/kirby#8319. While going through the page I noticed a few permissions were never documented:

- `files.read`
- `pages.read`
- `site.preview`
- the whole `languages` category (`create`, `delete`, `update`)