### PR TITLE
docs: Document page.move hooks

### DIFF
--- a/content/docs/2_reference/7_plugins/2_hooks/0_page-move-before/reference-hook.txt
+++ b/content/docs/2_reference/7_plugins/2_hooks/0_page-move-before/reference-hook.txt
@@ -1,0 +1,5 @@
+Details:
+
+<info>
+Note that the `page.move:before` hook is not called if the page already lives inside the given parent. In that case `$page->move()` returns early without triggering any hooks.
+</info>

--- a/content/docs/2_reference/7_plugins/2_hooks/hooks.csv
+++ b/content/docs/2_reference/7_plugins/2_hooks/hooks.csv
@@ -37,6 +37,8 @@ page.delete:after,"bool $status, Kirby\Cms\Page $page",trigger,
 page.delete:before,"Kirby\Cms\Page $page, bool $force",trigger,
 page.duplicate:after,"Kirby\Cms\Page $duplicatePage, Kirby\Cms\Page $originalPage",trigger,
 page.duplicate:before,"Kirby\Cms\Page $originalPage, array $input, array $options",trigger,
+page.move:after,"Kirby\Cms\Page $newPage, Kirby\Cms\Page $oldPage",trigger,
+page.move:before,"Kirby\Cms\Page $page, Kirby\Cms\Site|Kirby\Cms\Page $parent",trigger,
 page.render:after,"string $contentType, array $data, string $html, Kirby\Cms\Page $page",apply,$html
 page.render:before,"string $contentType, array $data, Kirby\Cms\Page $page",apply,$data
 page.update:after,"Kirby\Cms\Page $newPage, Kirby\Cms\Page $oldPage",trigger,


### PR DESCRIPTION
## Changelog

### 🐛 Bug fixes

- Document `page.move:before` and `page.move:after` hooks #2564